### PR TITLE
Kernel API: replace ip_tunnel_get_stats64 by dev_get_tstats64

### DIFF
--- a/gtp5g.c
+++ b/gtp5g.c
@@ -1606,7 +1606,11 @@ static const struct net_device_ops gtp5g_netdev_ops = {
     .ndo_init           = gtp5g_dev_init,
     .ndo_uninit         = gtp5g_dev_uninit,
     .ndo_start_xmit     = gtp5g_dev_xmit,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+    .ndo_get_stats64    = dev_get_tstats64,
+#else
     .ndo_get_stats64    = ip_tunnel_get_stats64,
+#endif
 };
 
 static void pdr_context_free(struct rcu_head *head)


### PR DESCRIPTION
Seems that the symbol was renamed starting from Linux 5.11.

Patch series says that functionally it remains the same:
 https://lore.kernel.org/all/059fcb95-fba8-673e-0cd6-fb26e8ed4861@gmail.com/T/

Issue: https://github.com/free5gc/gtp5g/issues/18