### PR TITLE
Paging netlink

### DIFF
--- a/include/encap.h
+++ b/include/encap.h
@@ -6,6 +6,24 @@
 #include "dev.h"
 #include "pktinfo.h"
 
+enum gtp5g_buffer_attrs {
+    /* gtp5g_device_attrs in this part */
+
+    GTP5G_BUFFER_PAD = 3,
+    GTP5G_BUFFER_PACKET,
+    GTP5G_BUFFER_ID,
+    GTP5G_BUFFER_SEID,
+    GTP5G_BUFFER_ACTION,
+
+    /* Add newly supported feature ON ABOVE
+     * for compatability with older version of
+     * free5GC's UPF or libgtp5gnl
+     * */
+
+    __GTP5G_BUFFER_ATTR_MAX,
+};
+#define GTP5G_BUFFER_ATTR_MAX (__GTP5G_BUFFER_ATTR_MAX - 1)
+
 extern struct sock *gtp5g_encap_enable(int, int, struct gtp5g_dev *);
 extern void gtp5g_encap_disable(struct sock *);
 extern int gtp5g_handle_skb_ipv4(struct sk_buff *, struct net_device *,

--- a/include/genl.h
+++ b/include/genl.h
@@ -34,6 +34,8 @@ enum gtp5g_cmd {
 
     GTP5G_CMD_GET_REPORT,
 
+    GTP5G_CMD_BUFFER_GTPU,
+
     __GTP5G_CMD_MAX,
 };
 #define GTP5G_CMD_MAX (__GTP5G_CMD_MAX - 1)
@@ -46,6 +48,10 @@ enum gtp5g_cmd {
 enum gtp5g_device_attrs {
     GTP5G_LINK = 1,
     GTP5G_NET_NS_FD,
+};
+
+enum gtp5g_multicast_groups {
+	GTP5G_GENL_MCGRP,
 };
 
 extern struct genl_family gtp5g_genl_family;

--- a/include/pdr.h
+++ b/include/pdr.h
@@ -109,4 +109,9 @@ extern void unix_sock_client_delete(struct pdr *);
 extern int unix_sock_client_new(struct pdr *);
 extern int unix_sock_client_update(struct pdr *);
 
+static inline bool pdr_addr_is_netlink(struct pdr *pdr)
+{
+    return (pdr->addr_unix.sun_path[0] == '/' && pdr->addr_unix.sun_path[1] == 0);
+}
+
 #endif // __PDR_H__

--- a/src/genl/genl.c
+++ b/src/genl/genl.c
@@ -159,6 +159,10 @@ static const struct genl_ops gtp5g_genl_ops[] = {
     },
 };
 
+static const struct genl_multicast_group gtp5g_genl_mcgrps[] = {
+	[GTP5G_GENL_MCGRP] = { .name = "gtp5g" },
+};
+
 struct genl_family gtp5g_genl_family __ro_after_init = {
     .name       = "gtp5g",
     .version    = 0,
@@ -168,4 +172,6 @@ struct genl_family gtp5g_genl_family __ro_after_init = {
     .module     = THIS_MODULE,
     .ops        = gtp5g_genl_ops,
     .n_ops      = ARRAY_SIZE(gtp5g_genl_ops),
+    .mcgrps     = gtp5g_genl_mcgrps,
+    .n_mcgrps   = ARRAY_SIZE(gtp5g_genl_mcgrps),
 };

--- a/src/gtpu/encap.c
+++ b/src/gtpu/encap.c
@@ -349,7 +349,7 @@ static int gtp5g_buf_skb_encap(struct sk_buff *skb, struct net_device *dev,
         if (pdr_addr_is_netlink(pdr)) {
             if (netlink_send(pdr, skb, dev_net(dev)) < 0) {
                 GTP5G_ERR(dev, "Failed to send skb to netlink socket PDR(%u)", pdr->id);
-                ++pdr->dl_drop_cnt;
+                ++pdr->ul_drop_cnt;
             }
         } else {
             if (unix_sock_send(pdr, skb->data, skb_headlen(skb), 0) < 0) {

--- a/src/gtpu/encap.c
+++ b/src/gtpu/encap.c
@@ -40,6 +40,7 @@ static int gtp1u_udp_encap_recv(struct gtp5g_dev *, struct sk_buff *);
 static int gtp5g_rx(struct pdr *, struct sk_buff *, unsigned int, unsigned int);
 static int gtp5g_fwd_skb_encap(struct sk_buff *, struct net_device *,
         unsigned int, struct pdr *, uint64_t);
+static int netlink_send(struct pdr *, struct sk_buff *, struct net *);
 static int unix_sock_send(struct pdr *, void *, u32, u32);
 static int gtp5g_fwd_skb_ipv4(struct sk_buff *, 
     struct net_device *, struct gtp5g_pktinfo *, 
@@ -345,12 +346,81 @@ static int gtp5g_buf_skb_encap(struct sk_buff *skb, struct net_device *dev,
             return -1;
         }
 
-        if (unix_sock_send(pdr, skb->data, skb_headlen(skb), 0) < 0) {
-            GTP5G_ERR(dev, "Failed to send skb to unix domain socket PDR(%u)", pdr->id);
-            ++pdr->ul_drop_cnt;
+        if (pdr_addr_is_netlink(pdr)) {
+            if (netlink_send(pdr, skb, dev_net(dev)) < 0) {
+                GTP5G_ERR(dev, "Failed to send skb to netlink socket PDR(%u)", pdr->id);
+                ++pdr->dl_drop_cnt;
+            }
+        } else {
+            if (unix_sock_send(pdr, skb->data, skb_headlen(skb), 0) < 0) {
+                GTP5G_ERR(dev, "Failed to send skb to unix domain socket PDR(%u)", pdr->id);
+                ++pdr->ul_drop_cnt;
+            }
         }
     }
     dev_kfree_skb(skb);
+    return 0;
+}
+
+/* Function netlink_{...} are used to handle buffering */
+// Send PDR ID, FAR action and buffered packet to user space
+static int netlink_send(struct pdr *pdr, struct sk_buff *skb_in, struct net *net)
+{
+    struct sk_buff *skb;
+    static atomic_t seq_counter;
+    u32 seq;
+    void *header;
+    struct nlattr *attr;
+    int err;
+
+    skb = genlmsg_new(
+        nla_total_size_64bit(8) +
+            nla_total_size(2) +
+            nla_total_size(2) +
+            nla_total_size(skb_in->len),
+        GFP_ATOMIC);
+    if (!skb)
+        return -ENOMEM;
+
+    seq = atomic_inc_return(&seq_counter);
+    header = genlmsg_put(skb, 0, seq, &gtp5g_genl_family, 0, GTP5G_CMD_BUFFER_GTPU);
+    if (!header)
+    {
+        nlmsg_free(skb);
+        return -ENOMEM;
+    }
+
+    err = nla_put_u16(skb, GTP5G_BUFFER_ID, pdr->id);
+    if (err != 0)
+    {
+        nlmsg_free(skb);
+        return err;
+    }
+
+    err = nla_put_u64_64bit(skb, GTP5G_BUFFER_SEID, pdr->seid, GTP5G_BUFFER_PAD);
+    if (err != 0)
+    {
+        nlmsg_free(skb);
+        return err;
+    }
+
+    err = nla_put_u16(skb, GTP5G_BUFFER_ACTION, pdr->far->action);
+    if (err != 0)
+    {
+        nlmsg_free(skb);
+        return err;
+    }
+
+    attr = nla_reserve(skb, GTP5G_BUFFER_PACKET, skb_in->len);
+    if (!attr)
+    {
+        nlmsg_free(skb);
+        return -EINVAL;
+    }
+    skb_copy_bits(skb_in, 0, nla_data(attr), skb_in->len);
+
+    genlmsg_end(skb, header);
+    genlmsg_multicast_netns(&gtp5g_genl_family, net, skb, 0, GTP5G_GENL_MCGRP, GFP_ATOMIC);
     return 0;
 }
 
@@ -771,10 +841,17 @@ err:
 static int gtp5g_buf_skb_ipv4(struct sk_buff *skb, struct net_device *dev,
     struct pdr *pdr)
 {
-    // TODO: handle nonlinear part
-    if (unix_sock_send(pdr, skb->data, skb_headlen(skb), 0) < 0) {
-        GTP5G_ERR(dev, "Failed to send skb to unix domain socket PDR(%u)", pdr->id);
-        ++pdr->dl_drop_cnt;
+    if (pdr_addr_is_netlink(pdr)) {
+        if (netlink_send(pdr, skb, dev_net(dev)) < 0) {
+            GTP5G_ERR(dev, "Failed to send skb to netlink socket PDR(%u)", pdr->id);
+            ++pdr->dl_drop_cnt;
+        }
+    } else {
+        // TODO: handle nonlinear part
+        if (unix_sock_send(pdr, skb->data, skb_headlen(skb), 0) < 0) {
+            GTP5G_ERR(dev, "Failed to send skb to unix domain socket PDR(%u)", pdr->id);
+            ++pdr->dl_drop_cnt;
+        }
     }
 
     dev_kfree_skb(skb);

--- a/src/pfcp/pdr.c
+++ b/src/pfcp/pdr.c
@@ -117,6 +117,9 @@ int unix_sock_client_new(struct pdr *pdr)
         return -EINVAL;
     }
 
+    if (pdr_addr_is_netlink(pdr))
+        return 0;
+
     err = sock_create(AF_UNIX, SOCK_DGRAM, 0, psock);
     if (err) {
         return err;


### PR DESCRIPTION
To fix https://github.com/free5gc/gtp5g/issues/15.

We use netlink instead of unix domain socket to send buffering packet to UPF NF in userland.
 