### PR TITLE
Guard pdr::far and far::fwd_param by RCU macros

### DIFF
--- a/include/far.h
+++ b/include/far.h
@@ -48,7 +48,7 @@ struct far {
     u64 seid;
     u32 id;
     u16 action;
-    struct forwarding_parameter *fwd_param;
+    struct forwarding_parameter __rcu *fwd_param;
     u8 *bar_id;
     struct bar *bar;
     struct net_device *dev;

--- a/include/pdr.h
+++ b/include/pdr.h
@@ -65,7 +65,7 @@ struct pdr {
     u8 *outer_header_removal;
     struct pdi *pdi;
     u32 *far_id;
-    struct far *far;
+    struct far __rcu *far;
     u32 *qer_ids; 
     u32 qer_num;
     u8  qfi;
@@ -108,7 +108,7 @@ extern void pdr_update_hlist_table(struct pdr *, struct gtp5g_dev *);
 
 extern void unix_sock_client_delete(struct pdr *);
 extern int unix_sock_client_new(struct pdr *);
-extern int unix_sock_client_update(struct pdr *);
+extern int unix_sock_client_update(struct pdr *, struct far *);
 
 static inline bool pdr_addr_is_netlink(struct pdr *pdr)
 {

--- a/src/genl/genl_pdr.c
+++ b/src/genl/genl_pdr.c
@@ -404,6 +404,7 @@ static int pdr_fill(struct pdr *pdr, struct gtp5g_dev *gtp, struct genl_info *in
     int err;
     struct nlattr *hdr = nlmsg_attrdata(info->nlhdr, 0);
     int remaining = nlmsg_attrlen(info->nlhdr, 0);
+    struct far *far;
 
     pdr->seid = 0;
 
@@ -468,7 +469,8 @@ static int pdr_fill(struct pdr *pdr, struct gtp5g_dev *gtp, struct genl_info *in
         return -EINVAL;
 
     pdr->af = AF_INET;
-    pdr->far = find_far_by_id(gtp, pdr->seid, *pdr->far_id);
+    far = find_far_by_id(gtp, pdr->seid, *pdr->far_id);
+    rcu_assign_pointer(pdr->far, far);
 
     err = far_set_pdr(pdr, gtp);
     if (err)
@@ -484,7 +486,7 @@ static int pdr_fill(struct pdr *pdr, struct gtp5g_dev *gtp, struct genl_info *in
 
     set_pdr_qfi(pdr, gtp);
 
-    if (unix_sock_client_update(pdr) < 0)
+    if (unix_sock_client_update(pdr, far) < 0)
         return -EINVAL;
 
     // Update hlist table

--- a/src/pfcp/far.c
+++ b/src/pfcp/far.c
@@ -17,7 +17,7 @@ static void far_context_free(struct rcu_head *head)
     if (!far)
         return;
 
-    fwd_param = far->fwd_param;
+    fwd_param = rcu_dereference(far->fwd_param);
     if (fwd_param) {
         if (fwd_param->hdr_creation)
             kfree(fwd_param->hdr_creation);
@@ -48,7 +48,7 @@ void far_context_delete(struct far *far)
     hlist_for_each_entry_rcu(pdr_node, head, hlist) {
         if (pdr_node->pdr->seid == far->seid &&
             *pdr_node->pdr->far_id == far->id) {
-            pdr_node->pdr->far = NULL;
+            rcu_assign_pointer(pdr_node->pdr->far, NULL);
             unix_sock_client_delete(pdr_node->pdr);
         }
     }
@@ -88,8 +88,8 @@ void far_update(struct far *far, struct gtp5g_dev *gtp, u8 *flag,
                 epkt_info->role_addr = pdr_node->pdr->role_addr_ipv4.s_addr;
                 epkt_info->sk = pdr_node->pdr->sk;
             }
-            pdr_node->pdr->far = far;
-            unix_sock_client_update(pdr_node->pdr);
+            rcu_assign_pointer(pdr_node->pdr->far, far);
+            unix_sock_client_update(pdr_node->pdr, far);
         }
     }
 }

--- a/src/pfcp/pdr.c
+++ b/src/pfcp/pdr.c
@@ -133,14 +133,10 @@ int unix_sock_client_new(struct pdr *pdr)
 }
 
 // Handle PDR/FAR changed and affect buffering
-int unix_sock_client_update(struct pdr *pdr)
+int unix_sock_client_update(struct pdr *pdr, struct far *far)
 {
-    struct far *far = NULL;
-
     if (!pdr || pdr_addr_is_netlink(pdr))
         return 0;
-
-    far = pdr->far;
 
     unix_sock_client_delete(pdr);
 

--- a/src/pfcp/qer.c
+++ b/src/pfcp/qer.c
@@ -3,6 +3,7 @@
 #include "dev.h"
 #include "qer.h"
 #include "pdr.h"
+#include "far.h"
 #include "seid.h"
 #include "hash.h"
 
@@ -72,7 +73,7 @@ void qer_update(struct qer *qer, struct gtp5g_dev *gtp)
     head = &gtp->related_qer_hash[str_hashfn(seid_qer_id_hexstr) % gtp->hash_size];
     hlist_for_each_entry_rcu(pdr_node, head, hlist) {
         if (pdr_node->pdr != NULL && find_qer_id_in_pdr(pdr_node->pdr, qer->id)) {
-            unix_sock_client_update(pdr_node->pdr);
+            unix_sock_client_update(pdr_node->pdr, rcu_dereference(pdr_node->pdr->far));
         }
     }
 }

--- a/src/proc.c
+++ b/src/proc.c
@@ -357,6 +357,7 @@ static ssize_t proc_far_write(struct file *filp, const char __user *buffer,
     unsigned long buf_len = min(sizeof(buf) - 1, len);
     struct far *far;
     struct gtp5g_dev *gtp;
+    struct forwarding_parameter *fwd_param;
 
     if (copy_from_user(buf, buffer, buf_len)) {
         GTP5G_ERR(NULL, "Failed to read buffer: %s\n", buf);
@@ -391,11 +392,12 @@ static ssize_t proc_far_write(struct file *filp, const char __user *buffer,
     proc_far.seid = far->seid;
     proc_far.action = far->action;
 
-    if (far->fwd_param) {
-        if (far->fwd_param->hdr_creation) {
-            proc_far.description = far->fwd_param->hdr_creation->description;
-            proc_far.teid = far->fwd_param->hdr_creation->teid;
-            proc_far.peer_addr4 = far->fwd_param->hdr_creation->peer_addr_ipv4.s_addr;
+    fwd_param = rcu_dereference(far->fwd_param);
+    if (fwd_param) {
+        if (fwd_param->hdr_creation) {
+            proc_far.description = fwd_param->hdr_creation->description;
+            proc_far.teid = fwd_param->hdr_creation->teid;
+            proc_far.peer_addr4 = fwd_param->hdr_creation->peer_addr_ipv4.s_addr;
         }
     }
 


### PR DESCRIPTION
In current codes, if the field far in struct pdr was changed to NULL during packet forwarding process, NULL access occurs.
To avoid this, rcu_derefernce() macro was used for reading field *far in struct pdr, reading result is reused subroutines.
The field fwd_param in struct far is treated in the same way.