### PR TITLE
Fix incorrect kernel version for conditional compilation

### DIFF
--- a/src/gtpu/pktinfo.c
+++ b/src/gtpu/pktinfo.c
@@ -80,7 +80,7 @@ struct rtable *ip4_find_route(struct sk_buff *skb, struct iphdr *iph,
         mtu = dst_mtu(&rt->dst);
     }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0) || defined(RHEL8)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 8) || defined(RHEL8)
        rt->dst.ops->update_pmtu(&rt->dst, NULL, skb, mtu, false);
 #else
        rt->dst.ops->update_pmtu(&rt->dst, NULL, skb, mtu);


### PR DESCRIPTION
Fixes #66.

An additional parameter confirm_neigh is added to update_pmtu after Linux 5.4.8 rather than Linux 5.4.0.
This fix allows kernel version between 5.4.0 to 5.4.7 to compile without error.