### PR TITLE
fix: remove all the header in the correct way

### DIFF
--- a/src/gtpu/encap.c
+++ b/src/gtpu/encap.c
@@ -887,9 +887,9 @@ static int gtp5g_fwd_skb_ipv4(struct sk_buff *skb,
     pdr->dl_byte_cnt += skb->len;
     GTP5G_INF(NULL, "PDR (%u) DL_PKT_CNT (%llu) DL_BYTE_CNT (%llu)", pdr->id, pdr->dl_pkt_cnt, pdr->dl_byte_cnt);
 
-    gtp5g_push_header(skb, pktinfo);
-
     volume = ip4_rm_header(skb, 0);
+
+    gtp5g_push_header(skb, pktinfo);
 
     if (pdr->urr_num != 0) {
         if (check_urr(pdr, far, volume, volume_mbqe, false) < 0)

--- a/src/gtpu/pktinfo.c
+++ b/src/gtpu/pktinfo.c
@@ -52,10 +52,11 @@ u64 ip4_rm_header(struct sk_buff *skb, unsigned int hdrlen){
     skb_copy = &tmp;
 
     volume = skb->len;
-
+    // packets from N6
     if (hdrlen == 0) {
         iph = ip_hdr(skb);
         volume -= network_and_transport_header_len(skb_copy);
+    // packets from N3/N9
     } else if (hdrlen > 0) {
         volume -= hdrlen;
 

--- a/src/gtpu/pktinfo.c
+++ b/src/gtpu/pktinfo.c
@@ -34,7 +34,7 @@ u64 ip4_rm_header(struct sk_buff *skb, unsigned int hdrlen){
             volume -= 8; // udp header len = 8B
             break;
         default:
-            return 0;
+            break;
         }
     } else if (hdrlen > 0) {
         volume -= hdrlen;

--- a/src/gtpu/pktinfo.c
+++ b/src/gtpu/pktinfo.c
@@ -42,7 +42,6 @@ u64 network_and_transport_header_len(struct sk_buff *skb){
 }
 
 u64 ip4_rm_header(struct sk_buff *skb, unsigned int hdrlen){
-    struct iphdr *iph;
     struct sk_buff *skb_copy, tmp;
     u64 volume;
 
@@ -54,7 +53,6 @@ u64 ip4_rm_header(struct sk_buff *skb, unsigned int hdrlen){
     volume = skb->len;
     if (hdrlen == 0) {
         // packets without gtp header
-        iph = ip_hdr(skb);
         volume -= network_and_transport_header_len(skb_copy);
     } else if (hdrlen > 0) {
         // packets with gtp header

--- a/src/gtpu/pktinfo.c
+++ b/src/gtpu/pktinfo.c
@@ -52,12 +52,12 @@ u64 ip4_rm_header(struct sk_buff *skb, unsigned int hdrlen){
     skb_copy = &tmp;
 
     volume = skb->len;
-    // packets from N6
     if (hdrlen == 0) {
+        // packets from N6
         iph = ip_hdr(skb);
         volume -= network_and_transport_header_len(skb_copy);
-    // packets from N3/N9
     } else if (hdrlen > 0) {
+        // packets from N3/N9
         volume -= hdrlen;
 
         skb_copy->len -= hdrlen;

--- a/src/gtpu/pktinfo.c
+++ b/src/gtpu/pktinfo.c
@@ -16,15 +16,10 @@
 u64 ip4_rm_header(struct sk_buff *skb, unsigned int hdrlen){
     struct iphdr *iph, *inner_iph;
     struct tcphdr *tcp;
-    struct udphdr *udp;
     struct sk_buff *inner_skb, tmp;
     u64 volume;
 
     volume = skb->len;
-    // hdrlen included the header length of UDP
-    // Deduct the header length of transport layer
-
-    udp = udp_hdr(skb);
 
     if (hdrlen == 0) {
         iph = ip_hdr(skb);

--- a/src/gtpu/pktinfo.c
+++ b/src/gtpu/pktinfo.c
@@ -53,11 +53,11 @@ u64 ip4_rm_header(struct sk_buff *skb, unsigned int hdrlen){
 
     volume = skb->len;
     if (hdrlen == 0) {
-        // packets from N6
+        // packets without gtp header
         iph = ip_hdr(skb);
         volume -= network_and_transport_header_len(skb_copy);
     } else if (hdrlen > 0) {
-        // packets from N3/N9
+        // packets with gtp header
         volume -= hdrlen;
 
         skb_copy->len -= hdrlen;


### PR DESCRIPTION
1. perform ip4_rm_header before the gtp5g_push_header in the gtp5g_fwd_skb_ipv4 to prevent calculate the volume of the pushed header
2.  Not sure why pskb_may_pull in gtp1u_udp_encap_recv do not move the skb->data & skb-len forward hdrlen. Therefore, instead of deducting the Ipv4 & TCP header under GPRS tunneling protocol, it repeatedly deducts the hdrlen.