### PR TITLE
Use systemd directory on make install/uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,10 +90,10 @@ install:
 	modprobe udp_tunnel
 	$(DEPMOD)
 	modprobe $(MODULE_NAME)
-	echo "gtp5g" >> /etc/modules
+	echo "gtp5g" > /etc/modules-load.d/gtp5g.conf
 
 uninstall:
 	rm -f $(DESTDIR)/lib/modules/$(KVER)/$(MOD_KERNEL_PATH)/$(MODULE_NAME).ko
 	$(DEPMOD)
-	sed -zi "s/gtp5g\n//g" /etc/modules
+        rm -f /etc/modules-load.d/gtp5g.conf
 	rmmod -f  $(MODULE_NAME)


### PR DESCRIPTION
Hi!

The current makefile doesn't install gtp5g module on operating systems that use systemd. This PR fixes it, by creating a `gtp5g.conf` file containing only the string `gtp5g` inside it, then `systemd` will load this module at the system startup.

This PR also makes `make uninstall` remove that file instead of removing the string `gtp5g` from `/etc/modules`.