### PR TITLE
Support GTP-U Sequence number for DL pkt in psaUPF

### DIFF
--- a/include/far.h
+++ b/include/far.h
@@ -48,6 +48,7 @@ struct far {
     u64 seid;
     u32 id;
     u16 action;
+    u16 seq_number;
     struct forwarding_parameter __rcu *fwd_param;
     u8 *bar_id;
     struct bar *bar;

--- a/include/pdr.h
+++ b/include/pdr.h
@@ -114,6 +114,9 @@ extern int unix_sock_client_update(struct pdr *, struct far *);
 extern int get_qos_enable(void);
 extern void set_qos_enable(int);
 
+extern int get_seq_enable(void);
+extern void set_seq_enable(int);
+
 static inline bool pdr_addr_is_netlink(struct pdr *pdr)
 {
     return (pdr->addr_unix.sun_path[0] == '/' && pdr->addr_unix.sun_path[1] == 0);

--- a/include/pktinfo.h
+++ b/include/pktinfo.h
@@ -13,6 +13,7 @@ struct gtp5g_pktinfo {
     struct rtable                 *rt;
     struct outer_header_creation  *hdr_creation;
     u8                            qfi;
+    u16                           seq_number;
     struct net_device             *dev;
     __be16                        gtph_port;
 };
@@ -42,7 +43,7 @@ extern void gtp5g_xmit_skb_ipv4(struct sk_buff *, struct gtp5g_pktinfo *);
 extern void gtp5g_set_pktinfo_ipv4(struct gtp5g_pktinfo *,
         struct sock *, struct iphdr *,
         struct outer_header_creation *,
-        u8, struct rtable *, struct flowi4 *,
+        u8, u16, struct rtable *, struct flowi4 *,
         struct net_device *);
 extern void gtp5g_push_header(struct sk_buff *, struct gtp5g_pktinfo *);
 

--- a/src/genl/genl_far.c
+++ b/src/genl/genl_far.c
@@ -469,6 +469,7 @@ static int far_fill(struct far *far, struct gtp5g_dev *gtp, struct genl_info *in
         return -EINVAL;
 
     far->id = nla_get_u32(info->attrs[GTP5G_FAR_ID]);
+    far->seq_number = 0;
 
     if (info->attrs[GTP5G_FAR_SEID])
         far->seid = nla_get_u64(info->attrs[GTP5G_FAR_SEID]);

--- a/src/gtpu/encap.c
+++ b/src/gtpu/encap.c
@@ -924,10 +924,12 @@ static int gtp5g_fwd_skb_ipv4(struct sk_buff *skb,
             iph, 
             hdr_creation,
             pdr->qfi, 
+            far->seq_number,
             rt, 
             &fl4, 
             dev);
 
+    far->seq_number++;
     pdr->dl_pkt_cnt++;
     pdr->dl_byte_cnt += skb->len;
     GTP5G_INF(NULL, "PDR (%u) DL_PKT_CNT (%llu) DL_BYTE_CNT (%llu)", pdr->id, pdr->dl_pkt_cnt, pdr->dl_byte_cnt);

--- a/src/pfcp/far.c
+++ b/src/pfcp/far.c
@@ -4,7 +4,7 @@
 #include "seid.h"
 #include "hash.h"
 
-int seq_enable = 0; // set Seq disable as default value
+int seq_enable = 1; // set Seq enable as default value
 
 int get_seq_enable()
 {

--- a/src/pfcp/far.c
+++ b/src/pfcp/far.c
@@ -4,6 +4,18 @@
 #include "seid.h"
 #include "hash.h"
 
+int seq_enable = 0; // set Seq disable as default value
+
+int get_seq_enable()
+{
+    return seq_enable;
+}
+
+void set_seq_enable(int val)
+{
+    seq_enable = val;
+}
+
 static void seid_far_id_to_hex_str(u64 seid_int, u32 far_id, char *buff)
 {
     seid_and_u32id_to_hex_str(seid_int, far_id, buff);

--- a/src/proc.c
+++ b/src/proc.c
@@ -83,6 +83,11 @@ struct proc_gtp5g_qos
     bool qos_enable;
 };
 
+struct proc_gtp5g_seq
+{
+    bool seq_enable;
+};
+
 struct proc_dir_entry *proc_gtp5g = NULL;
 struct proc_dir_entry *proc_gtp5g_dbg = NULL;
 struct proc_dir_entry *proc_gtp5g_pdr = NULL;
@@ -90,11 +95,13 @@ struct proc_dir_entry *proc_gtp5g_far = NULL;
 struct proc_dir_entry *proc_gtp5g_qer = NULL;
 struct proc_dir_entry *proc_gtp5g_urr = NULL;
 struct proc_dir_entry *proc_gtp5g_qos = NULL;
+struct proc_dir_entry *proc_gtp5g_seq = NULL;
 struct proc_gtp5g_pdr proc_pdr;
 struct proc_gtp5g_far proc_far;
 struct proc_gtp5g_qer proc_qer;
 struct proc_gtp5g_urr proc_urr;
 struct proc_gtp5g_qos proc_qos;
+struct proc_gtp5g_seq proc_seq;
 
 u64 proc_seid = 0;
 u16 proc_pdr_id = 0;
@@ -299,6 +306,39 @@ static ssize_t proc_qos_write(struct file *filp, const char __user *buffer,
      
     set_qos_enable(qos_enable);
     GTP5G_TRC(NULL, "qos enable:%d", get_qos_enable());
+    return strnlen(buf, buf_len);
+err:
+    return -1;
+}
+
+
+static int gtp5g_seq_read(struct seq_file *s, void *v)
+{
+    GTP5G_TRC(NULL, "gtp5g_seq_read");
+    seq_printf(s, "Sequence Number Enable: %d\n", get_seq_enable());
+    return 0;
+}
+
+static ssize_t proc_seq_write(struct file *filp, const char __user *buffer,
+    size_t len, loff_t *dptr) 
+{
+    char buf[16];
+    unsigned long buf_len = min(len, sizeof(buf) - 1);
+    int seq_enable;
+
+    if (copy_from_user(buf, buffer, buf_len)) {
+        GTP5G_ERR(NULL, "Failed to read buffer: %s\n", buffer);
+        goto err;
+    }
+    
+    buf[buf_len] = 0;
+    if (sscanf(buf, "%d", &seq_enable) != 1) {
+        GTP5G_ERR(NULL, "Failed to read seq enable setting: %s\n", buffer);
+        goto err;
+    }
+     
+    set_seq_enable(seq_enable);
+    GTP5G_TRC(NULL, "seq enable:%d", get_seq_enable());
     return strnlen(buf, buf_len);
 err:
     return -1;
@@ -583,6 +623,11 @@ static int proc_qos_read(struct inode *inode, struct file *file)
     return single_open(file, gtp5g_qos_read, NULL);
 }
 
+static int proc_seq_read(struct inode *inode, struct file *file)
+{
+    return single_open(file, gtp5g_seq_read, NULL);
+}
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
 static const struct proc_ops proc_gtp5g_dbg_ops = {
     .proc_open = proc_dbg_read,
@@ -678,8 +723,6 @@ static const struct file_operations proc_gtp5g_urr_ops = {
 };
 #endif
 
-
-
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
 static const struct proc_ops proc_gtp5g_qos_ops = {
     .proc_open = proc_qos_read,
@@ -694,6 +737,25 @@ static const struct file_operations proc_gtp5g_qos_ops = {
     .open       = proc_qos_read,
     .read       = seq_read,
     .write      = proc_qos_write,
+    .llseek     = seq_lseek,
+    .release    = single_release,
+};
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+static const struct proc_ops proc_gtp5g_seq_ops = {
+    .proc_open = proc_seq_read,
+    .proc_read = seq_read,
+    .proc_write = proc_seq_write,
+    .proc_lseek = seq_lseek,
+    .proc_release = single_release,
+};
+#else
+static const struct file_operations proc_gtp5g_seq_ops = {
+    .owner      = THIS_MODULE,
+    .open       = proc_seq_read,
+    .read       = seq_read,
+    .write      = proc_seq_write,
     .llseek     = seq_lseek,
     .release    = single_release,
 };
@@ -748,8 +810,17 @@ int create_proc(void)
         goto remove_urr_proc;
     }
 
+    proc_gtp5g_seq = proc_create("seq", (S_IFREG | S_IRUGO | S_IWUGO),
+        proc_gtp5g, &proc_gtp5g_seq_ops);
+    if (!proc_gtp5g_seq) {
+        GTP5G_ERR(NULL, "Failed to create /proc/gtp5g/seq\n");
+        goto remove_qos_proc;
+    }
+
     return 0;
 
+    remove_qos_proc:
+        remove_proc_entry("qos", proc_gtp5g);
     remove_urr_proc:
         remove_proc_entry("urr", proc_gtp5g);
     remove_qer_proc:
@@ -768,6 +839,7 @@ int create_proc(void)
 void remove_proc()
 {
     remove_proc_entry("qos", proc_gtp5g);
+    remove_proc_entry("seq", proc_gtp5g);
     remove_proc_entry("urr", proc_gtp5g);
     remove_proc_entry("qer", proc_gtp5g);
     remove_proc_entry("far", proc_gtp5g);


### PR DESCRIPTION
Support GTP-U sequence number in GTP-U optional header, the S bit is set to 1 in the GTP-U header.
The sequence number ranges from 0 - 65535 (u16) and wraps around to 0 when the value reaches 65536. The sequence number is handled on a per GTP-U Tunnel (that is TEID) basis. [1]
This is a configurable feature that can be turned on/off by sending a value to `/proc/gtp5g/seq`. This feature is enabled by default and can be disabled by executing `echo 0 > /proc/gtp5g/seq`.

[1] TS 29.281 4.3.1 Handling of Sequence Numbers
