### PR TITLE
drop packets when the QER ULDL gate is closed

### DIFF
--- a/include/qer.h
+++ b/include/qer.h
@@ -8,6 +8,13 @@
 #include "dev.h"
 #include "pdr.h"
 
+// TS 29.244 8.2.7 Gate Status
+// 0 OPEN, 1 CLOSED
+// 2, 3 For future use. Shall not be sent.
+// If received, shall be interpreted as the value "1"
+#define QER_UL_GATE_CLOSE   0b00001100
+#define QER_DL_GATE_CLOSE   0b00000011
+
 struct qer {
     struct hlist_node hlist_id;
     u64 seid;

--- a/include/qer.h
+++ b/include/qer.h
@@ -12,8 +12,8 @@
 // 0 OPEN, 1 CLOSED
 // 2, 3 For future use. Shall not be sent.
 // If received, shall be interpreted as the value "1"
-#define QER_UL_GATE_CLOSE   0b00001100
-#define QER_DL_GATE_CLOSE   0b00000011
+#define QER_UL_GATE_CLOSE (0x1 << 2)
+#define QER_DL_GATE_CLOSE (0x1 << 0)
 
 struct qer {
     struct hlist_node hlist_id;

--- a/src/genl/genl_qer.c
+++ b/src/genl/genl_qer.c
@@ -7,6 +7,7 @@
 #include "genl_qer.h"
 #include "qer.h"
 #include "hash.h"
+#include "log.h"
 
 #include <linux/rculist.h>
 #include <net/netns/generic.h>
@@ -309,8 +310,10 @@ static int qer_fill(struct qer *qer, struct gtp5g_dev *gtp, struct genl_info *in
     else
         qer->seid = 0;
 
-    if (info->attrs[GTP5G_QER_GATE])
+    if (info->attrs[GTP5G_QER_GATE]){
         qer->ul_dl_gate = nla_get_u8(info->attrs[GTP5G_QER_GATE]);
+        GTP5G_INF(NULL, "QER Gate Status (%x)", qer->ul_dl_gate);
+    }
 
     /* MBR */
     if (info->attrs[GTP5G_QER_MBR] &&

--- a/src/genl/genl_qer.c
+++ b/src/genl/genl_qer.c
@@ -310,7 +310,7 @@ static int qer_fill(struct qer *qer, struct gtp5g_dev *gtp, struct genl_info *in
     else
         qer->seid = 0;
 
-    if (info->attrs[GTP5G_QER_GATE]){
+    if (info->attrs[GTP5G_QER_GATE]) {
         qer->ul_dl_gate = nla_get_u8(info->attrs[GTP5G_QER_GATE]);
         GTP5G_INF(NULL, "QER Gate Status (%x)", qer->ul_dl_gate);
     }


### PR DESCRIPTION
Support QoS Gate Status
According to TS 29.244 8.2.7 Gate Status
(0 OPEN, 1 CLOSED
2, 3 For future use. Shall not be sent.
If received, shall be interpreted as the value "1")