### PR TITLE
add api to get ul/dl packets counter & add srcIntf IE

### DIFF
--- a/include/dev.h
+++ b/include/dev.h
@@ -5,6 +5,13 @@
 #include <linux/rculist.h>
 #include <linux/socket.h>
 
+struct byte_pkt_cnt {
+    atomic_t                     ul_byte;
+    atomic_t                     dl_byte;
+    atomic_t                     ul_pkt;
+    atomic_t                     dl_pkt;
+};
+
 struct gtp5g_dev {
     struct list_head list;
     struct sock *sk1u; // UDP socket from user space
@@ -28,7 +35,12 @@ struct gtp5g_dev {
     
     /* Used by proc interface */
     struct list_head proc_list;
+
+    /* Packet Statistics */
+    struct byte_pkt_cnt rx, tx;    
 };
+
+extern void update_statistic(struct gtp5g_dev *, u64, int, uint);
 
 extern const struct net_device_ops gtp5g_netdev_ops;
 

--- a/include/dev.h
+++ b/include/dev.h
@@ -5,11 +5,11 @@
 #include <linux/rculist.h>
 #include <linux/socket.h>
 
-struct byte_pkt_cnt {
-    atomic_t                     ul_byte;
-    atomic_t                     dl_byte;
-    atomic_t                     ul_pkt;
-    atomic_t                     dl_pkt;
+struct usage_statistic {
+    atomic_t ul_byte;
+    atomic_t dl_byte;
+    atomic_t ul_pkt;
+    atomic_t dl_pkt;
 };
 
 struct gtp5g_dev {
@@ -36,11 +36,11 @@ struct gtp5g_dev {
     /* Used by proc interface */
     struct list_head proc_list;
 
-    /* Packet Statistics */
-    struct byte_pkt_cnt rx, tx;    
+    /* Usage Statistics */
+    struct usage_statistic rx, tx;
 };
 
-extern void update_statistic(struct gtp5g_dev *, u64, int, uint);
+extern void update_usage_statistic(struct gtp5g_dev *, u64, int, uint);
 
 extern const struct net_device_ops gtp5g_netdev_ops;
 

--- a/include/genl.h
+++ b/include/genl.h
@@ -38,11 +38,11 @@ enum gtp5g_cmd {
 
     GTP5G_CMD_GET_MULTI_REPORTS,
 
-    GTP5G_CMD_GET_ULDL_REPORT,
+    GTP5G_CMD_GET_USAGE_STATISTIC,
 
     __GTP5G_CMD_MAX,
 };
-#define GTP5G_CMD_MAX (__GTP5G_CMD_MAX - 1)
+#define GTP5G_CMD_MAX 32
 
 /* This const value need to bigger than the Layer 1 attr size,
  * like GTP5G_MSG_TYPE_ATTR_MAX(2), 

--- a/include/genl.h
+++ b/include/genl.h
@@ -38,6 +38,8 @@ enum gtp5g_cmd {
 
     GTP5G_CMD_GET_MULTI_REPORTS,
 
+    GTP5G_CMD_GET_ULDL_REPORT,
+
     __GTP5G_CMD_MAX,
 };
 #define GTP5G_CMD_MAX (__GTP5G_CMD_MAX - 1)

--- a/include/genl_pdr.h
+++ b/include/genl_pdr.h
@@ -37,6 +37,8 @@ enum gtp5g_pdi_attrs {
     GTP5G_PDI_UE_ADDR_IPV4,
     GTP5G_PDI_F_TEID,
     GTP5G_PDI_SDF_FILTER,
+    GTP5G_PDI_SRC_INTF,
+
     __GTP5G_PDI_ATTR_MAX,
 };
 #define GTP5G_PDI_ATTR_MAX 16

--- a/include/genl_report.h
+++ b/include/genl_report.h
@@ -40,8 +40,23 @@ enum gtp5g_multi_usage_report_attrs {
     __GTP5G_URS_ATTR_MAX,
 };
 
+enum gtp5g_ul_dl_report_attrs {
+    GTP5G_UPLINK_VOL_RX = 1,
+    GTP5G_UPLINK_VOL_TX,
+    GTP5G_DOWNLINK_VOL_RX,
+    GTP5G_DOWNLINK_VOL_TX,
+
+    GTP5G_UPLINK_PKT_RX,
+    GTP5G_UPLINK_PKT_TX,
+    GTP5G_DOWNLINK_PKT_RX,
+    GTP5G_DOWNLINK_PKT_TX,
+
+    __GTP5G_ULDL_ATTR_MAX,
+};
+
 extern int gtp5g_genl_get_usage_report(struct sk_buff *, struct genl_info *);
 extern int gtp5g_genl_get_multi_usage_reports(struct sk_buff *, struct genl_info *);
+extern int gtp5g_genl_get_ul_dl_report(struct sk_buff *, struct genl_info *);
 
 extern int gtp5g_genl_fill_ur(struct sk_buff *, struct usage_report *);
 extern int gtp5g_genl_fill_usage_report(struct sk_buff *, u32, u32, u32, struct usage_report *);

--- a/include/genl_report.h
+++ b/include/genl_report.h
@@ -40,23 +40,23 @@ enum gtp5g_multi_usage_report_attrs {
     __GTP5G_URS_ATTR_MAX,
 };
 
-enum gtp5g_ul_dl_report_attrs {
-    GTP5G_UPLINK_VOL_RX = 1,
-    GTP5G_UPLINK_VOL_TX,
-    GTP5G_DOWNLINK_VOL_RX,
-    GTP5G_DOWNLINK_VOL_TX,
+enum gtp5g_usage_statistic_attrs {
+    GTP5G_USTAT_UL_VOL_RX = 1,
+    GTP5G_USTAT_UL_VOL_TX,
+    GTP5G_USTAT_DL_VOL_RX,
+    GTP5G_USTAT_DL_VOL_TX,
 
-    GTP5G_UPLINK_PKT_RX,
-    GTP5G_UPLINK_PKT_TX,
-    GTP5G_DOWNLINK_PKT_RX,
-    GTP5G_DOWNLINK_PKT_TX,
+    GTP5G_USTAT_UL_PKT_RX,
+    GTP5G_USTAT_UL_PKT_TX,
+    GTP5G_USTAT_DL_PKT_RX,
+    GTP5G_USTAT_DL_PKT_TX,
 
-    __GTP5G_ULDL_ATTR_MAX,
+    __GTP5G_USTAT_ATTR_MAX,
 };
 
 extern int gtp5g_genl_get_usage_report(struct sk_buff *, struct genl_info *);
 extern int gtp5g_genl_get_multi_usage_reports(struct sk_buff *, struct genl_info *);
-extern int gtp5g_genl_get_ul_dl_report(struct sk_buff *, struct genl_info *);
+extern int gtp5g_genl_get_usage_statistic(struct sk_buff *, struct genl_info *);
 
 extern int gtp5g_genl_fill_ur(struct sk_buff *, struct usage_report *);
 extern int gtp5g_genl_fill_usage_report(struct sk_buff *, u32, u32, u32, struct usage_report *);

--- a/include/pdr.h
+++ b/include/pdr.h
@@ -41,7 +41,11 @@ struct sdf_filter {
     u32 *bi_id;
 };
 
+#define SRC_INTF_ACCESS 0
+#define SRC_INTF_CORE 1
+
 struct pdi {
+    u8 srcIntf;
     struct in_addr *ue_addr_ipv4;
     struct local_f_teid *f_teid;
     struct sdf_filter *sdf;

--- a/src/genl/genl.c
+++ b/src/genl/genl.c
@@ -164,8 +164,8 @@ static const struct genl_ops gtp5g_genl_ops[] = {
         .flags = GENL_ADMIN_PERM,
     },
     {
-        .cmd = GTP5G_CMD_GET_ULDL_REPORT,
-        .doit = gtp5g_genl_get_ul_dl_report,
+        .cmd = GTP5G_CMD_GET_USAGE_STATISTIC,
+        .doit = gtp5g_genl_get_usage_statistic,
         .flags = GENL_ADMIN_PERM,
     },
 };

--- a/src/genl/genl.c
+++ b/src/genl/genl.c
@@ -163,6 +163,11 @@ static const struct genl_ops gtp5g_genl_ops[] = {
         .doit = gtp5g_genl_get_multi_usage_reports,
         .flags = GENL_ADMIN_PERM,
     },
+    {
+        .cmd = GTP5G_CMD_GET_ULDL_REPORT,
+        .doit = gtp5g_genl_get_ul_dl_report,
+        .flags = GENL_ADMIN_PERM,
+    },
 };
 
 static const struct genl_multicast_group gtp5g_genl_mcgrps[] = {

--- a/src/genl/genl_pdr.c
+++ b/src/genl/genl_pdr.c
@@ -541,6 +541,10 @@ static int parse_pdi(struct pdr *pdr, struct nlattr *a)
             return err;
     }
 
+    if (attrs[GTP5G_PDI_SRC_INTF]) {
+        pdi->srcIntf = nla_get_u8(attrs[GTP5G_PDI_SRC_INTF]);
+    }
+
     if (attrs[GTP5G_PDI_SDF_FILTER]) {
         err = parse_sdf_filter(pdi, attrs[GTP5G_PDI_SDF_FILTER]);
         if (err)

--- a/src/genl/genl_report.c
+++ b/src/genl/genl_report.c
@@ -18,6 +18,93 @@
 static int gtp5g_genl_fill_volume_measurement(struct sk_buff *, struct VolumeMeasurement);
 static int parse_seid_urr(struct seid_urr *, struct nlattr *);
 
+static int gtp5g_genl_fill_ul_dl(struct gtp5g_dev *gtp_dev , struct sk_buff *skb, 
+        u32 snd_portid, u32 snd_seq, u32 type)
+{
+    void *genlh = NULL;
+
+    genlh = genlmsg_put(skb, snd_portid, snd_seq, &gtp5g_genl_family, 0, type);
+    if (!genlh)
+        goto genlmsg_fail;
+
+    if (nla_put_u64_64bit(skb, GTP5G_UPLINK_VOL_RX, (u64)atomic_read(&gtp_dev->rx.ul_byte), 0))
+        return -EMSGSIZE;
+    if (nla_put_u64_64bit(skb, GTP5G_UPLINK_VOL_TX, (u64)atomic_read(&gtp_dev->tx.ul_byte), 0))
+        return -EMSGSIZE;
+    if (nla_put_u64_64bit(skb, GTP5G_DOWNLINK_VOL_RX, (u64)atomic_read(&gtp_dev->rx.dl_byte), 0))
+        return -EMSGSIZE;
+    if (nla_put_u64_64bit(skb, GTP5G_DOWNLINK_VOL_TX, (u64)atomic_read(&gtp_dev->tx.dl_byte), 0))
+        return -EMSGSIZE;
+
+    if (nla_put_u64_64bit(skb, GTP5G_UPLINK_PKT_RX, (u64)atomic_read(&gtp_dev->rx.ul_pkt), 0))
+        return -EMSGSIZE;
+    if (nla_put_u64_64bit(skb, GTP5G_UPLINK_PKT_TX, (u64)atomic_read(&gtp_dev->tx.ul_pkt), 0))
+        return -EMSGSIZE;
+    if (nla_put_u64_64bit(skb, GTP5G_DOWNLINK_PKT_RX, (u64)atomic_read(&gtp_dev->rx.dl_pkt), 0))
+        return -EMSGSIZE;
+    if (nla_put_u64_64bit(skb, GTP5G_DOWNLINK_PKT_TX, (u64)atomic_read(&gtp_dev->tx.dl_pkt), 0))
+        return -EMSGSIZE;
+
+    genlmsg_end(skb, genlh);
+    return 0;
+
+genlmsg_fail:
+    genlmsg_cancel(skb, genlh);
+    return -EMSGSIZE;
+}
+
+int gtp5g_genl_get_ul_dl_report(struct sk_buff *skb, struct genl_info *info)
+{
+    struct sk_buff *skb_ack = NULL;
+    int err = 0;
+    int ifindex = 0;
+    int netnsfd = 0;
+    struct gtp5g_dev *gtp_dev = NULL;
+
+    if (!info->attrs[GTP5G_LINK])
+        return -EINVAL;
+    ifindex = nla_get_u32(info->attrs[GTP5G_LINK]);
+
+    if (info->attrs[GTP5G_NET_NS_FD])
+        netnsfd = nla_get_u32(info->attrs[GTP5G_NET_NS_FD]);
+    else
+        netnsfd = -1;
+
+    rcu_read_lock();
+
+    gtp_dev = gtp5g_find_dev(sock_net(skb->sk), ifindex, netnsfd);
+    if (!gtp_dev) {
+        err = -ENODEV;
+        goto fail;
+    }
+    
+    skb_ack = genlmsg_new(NLMSG_GOODSIZE, GFP_ATOMIC);
+    if (!skb_ack) {
+        return -ENOMEM;
+    }
+
+    err = gtp5g_genl_fill_ul_dl(gtp_dev, skb_ack,
+            NETLINK_CB(skb).portid,
+            info->snd_seq,
+            info->nlhdr->nlmsg_type);
+    if (err) {
+        kfree_skb(skb_ack);
+        return err;
+    }
+
+fail:
+    if (err) {
+        if (skb_ack) {
+            kfree_skb(skb_ack);
+        }
+        rcu_read_unlock();
+        return err;
+    }
+
+    rcu_read_unlock();
+    return genlmsg_unicast(genl_info_net(info), skb_ack, info->snd_portid);
+}
+
 int gtp5g_genl_get_usage_report(struct sk_buff *skb, struct genl_info *info)
 {
     struct gtp5g_dev *gtp;

--- a/src/genl/genl_report.c
+++ b/src/genl/genl_report.c
@@ -18,7 +18,7 @@
 static int gtp5g_genl_fill_volume_measurement(struct sk_buff *, struct VolumeMeasurement);
 static int parse_seid_urr(struct seid_urr *, struct nlattr *);
 
-static int gtp5g_genl_fill_ul_dl(struct gtp5g_dev *gtp_dev , struct sk_buff *skb, 
+static int gtp5g_genl_fill_usage_statistic(struct gtp5g_dev *gtp_dev , struct sk_buff *skb,
         u32 snd_portid, u32 snd_seq, u32 type)
 {
     void *genlh = NULL;
@@ -27,22 +27,22 @@ static int gtp5g_genl_fill_ul_dl(struct gtp5g_dev *gtp_dev , struct sk_buff *skb
     if (!genlh)
         goto genlmsg_fail;
 
-    if (nla_put_u64_64bit(skb, GTP5G_UPLINK_VOL_RX, (u64)atomic_read(&gtp_dev->rx.ul_byte), 0))
+    if (nla_put_u64_64bit(skb, GTP5G_USTAT_UL_VOL_RX, (u64)atomic_read(&gtp_dev->rx.ul_byte), 0))
         return -EMSGSIZE;
-    if (nla_put_u64_64bit(skb, GTP5G_UPLINK_VOL_TX, (u64)atomic_read(&gtp_dev->tx.ul_byte), 0))
+    if (nla_put_u64_64bit(skb, GTP5G_USTAT_UL_VOL_TX, (u64)atomic_read(&gtp_dev->tx.ul_byte), 0))
         return -EMSGSIZE;
-    if (nla_put_u64_64bit(skb, GTP5G_DOWNLINK_VOL_RX, (u64)atomic_read(&gtp_dev->rx.dl_byte), 0))
+    if (nla_put_u64_64bit(skb, GTP5G_USTAT_DL_VOL_RX, (u64)atomic_read(&gtp_dev->rx.dl_byte), 0))
         return -EMSGSIZE;
-    if (nla_put_u64_64bit(skb, GTP5G_DOWNLINK_VOL_TX, (u64)atomic_read(&gtp_dev->tx.dl_byte), 0))
+    if (nla_put_u64_64bit(skb, GTP5G_USTAT_DL_VOL_TX, (u64)atomic_read(&gtp_dev->tx.dl_byte), 0))
         return -EMSGSIZE;
 
-    if (nla_put_u64_64bit(skb, GTP5G_UPLINK_PKT_RX, (u64)atomic_read(&gtp_dev->rx.ul_pkt), 0))
+    if (nla_put_u64_64bit(skb, GTP5G_USTAT_UL_PKT_RX, (u64)atomic_read(&gtp_dev->rx.ul_pkt), 0))
         return -EMSGSIZE;
-    if (nla_put_u64_64bit(skb, GTP5G_UPLINK_PKT_TX, (u64)atomic_read(&gtp_dev->tx.ul_pkt), 0))
+    if (nla_put_u64_64bit(skb, GTP5G_USTAT_UL_PKT_TX, (u64)atomic_read(&gtp_dev->tx.ul_pkt), 0))
         return -EMSGSIZE;
-    if (nla_put_u64_64bit(skb, GTP5G_DOWNLINK_PKT_RX, (u64)atomic_read(&gtp_dev->rx.dl_pkt), 0))
+    if (nla_put_u64_64bit(skb, GTP5G_USTAT_DL_PKT_RX, (u64)atomic_read(&gtp_dev->rx.dl_pkt), 0))
         return -EMSGSIZE;
-    if (nla_put_u64_64bit(skb, GTP5G_DOWNLINK_PKT_TX, (u64)atomic_read(&gtp_dev->tx.dl_pkt), 0))
+    if (nla_put_u64_64bit(skb, GTP5G_USTAT_DL_PKT_TX, (u64)atomic_read(&gtp_dev->tx.dl_pkt), 0))
         return -EMSGSIZE;
 
     genlmsg_end(skb, genlh);
@@ -53,7 +53,7 @@ genlmsg_fail:
     return -EMSGSIZE;
 }
 
-int gtp5g_genl_get_ul_dl_report(struct sk_buff *skb, struct genl_info *info)
+int gtp5g_genl_get_usage_statistic(struct sk_buff *skb, struct genl_info *info)
 {
     struct sk_buff *skb_ack = NULL;
     int err = 0;
@@ -77,13 +77,13 @@ int gtp5g_genl_get_ul_dl_report(struct sk_buff *skb, struct genl_info *info)
         err = -ENODEV;
         goto fail;
     }
-    
+
     skb_ack = genlmsg_new(NLMSG_GOODSIZE, GFP_ATOMIC);
     if (!skb_ack) {
         return -ENOMEM;
     }
 
-    err = gtp5g_genl_fill_ul_dl(gtp_dev, skb_ack,
+    err = gtp5g_genl_fill_usage_statistic(gtp_dev, skb_ack,
             NETLINK_CB(skb).portid,
             info->snd_seq,
             info->nlhdr->nlmsg_type);

--- a/src/gtpu/dev.c
+++ b/src/gtpu/dev.c
@@ -42,7 +42,7 @@ struct gtp5g_dev *gtp5g_find_dev(struct net *src_net, int ifindex, int netnsfd)
     return gtp;
 }
 
-void update_statistic(struct gtp5g_dev *gtp, u64 vol, int pkt_action, uint srcIntf) 
+void update_usage_statistic(struct gtp5g_dev *gtp, u64 vol, int pkt_action, uint srcIntf)
 {
     switch (srcIntf) {
     case SRC_INTF_ACCESS: // uplink
@@ -112,8 +112,7 @@ static netdev_tx_t gtp5g_dev_xmit(struct sk_buff *skb, struct net_device *dev)
     switch (proto) {
     case ETH_P_IP:
         ret = gtp5g_handle_skb_ipv4(skb, dev, &pktinfo);
-        // update downlink packet count
-        update_statistic(gtp, skb->len, ret, SRC_INTF_CORE);
+        update_usage_statistic(gtp, skb->len, ret, SRC_INTF_CORE); // DL
         break;
     default:
         ret = -EOPNOTSUPP;

--- a/src/gtpu/dev.c
+++ b/src/gtpu/dev.c
@@ -11,6 +11,7 @@
 #include "bar.h"
 #include "urr.h"
 #include "pktinfo.h"
+#include "log.h"
 
 struct gtp5g_dev *gtp5g_find_dev(struct net *src_net, int ifindex, int netnsfd)
 {
@@ -41,6 +42,31 @@ struct gtp5g_dev *gtp5g_find_dev(struct net *src_net, int ifindex, int netnsfd)
     return gtp;
 }
 
+void update_statistic(struct gtp5g_dev *gtp, u64 vol, int pkt_action, uint srcIntf) 
+{
+    switch (srcIntf) {
+    case SRC_INTF_ACCESS: // uplink
+        atomic_add(vol, &gtp->rx.ul_byte);
+        atomic_inc(&gtp->rx.ul_pkt);
+        if (pkt_action != PKT_DROPPED) {
+            atomic_add(vol, &gtp->tx.ul_byte);
+            atomic_inc(&gtp->tx.ul_pkt);
+        }
+        break;
+    case SRC_INTF_CORE: // downlink
+        atomic_add(vol, &gtp->rx.dl_byte);
+        atomic_inc(&gtp->rx.dl_pkt);
+        if (pkt_action != PKT_DROPPED) {
+            atomic_add(vol, &gtp->tx.dl_byte);
+            atomic_inc(&gtp->tx.dl_pkt);
+        }
+        break;
+    default:
+        GTP5G_ERR(gtp->dev, "unknown srcIntf type\n");
+        break;
+    }
+}
+
 static int gtp5g_dev_init(struct net_device *dev)
 {
     struct gtp5g_dev *gtp = netdev_priv(dev);
@@ -68,6 +94,7 @@ static void gtp5g_dev_uninit(struct net_device *dev)
  * */
 static netdev_tx_t gtp5g_dev_xmit(struct sk_buff *skb, struct net_device *dev)
 {
+    struct gtp5g_dev *gtp = netdev_priv(dev);
     unsigned int proto = ntohs(skb->protocol);
     struct gtp5g_pktinfo pktinfo;
     int ret = 0;
@@ -85,6 +112,8 @@ static netdev_tx_t gtp5g_dev_xmit(struct sk_buff *skb, struct net_device *dev)
     switch (proto) {
     case ETH_P_IP:
         ret = gtp5g_handle_skb_ipv4(skb, dev, &pktinfo);
+        // update downlink packet count
+        update_statistic(gtp, skb->len, ret, SRC_INTF_CORE);
         break;
     default:
         ret = -EOPNOTSUPP;
@@ -94,7 +123,7 @@ static netdev_tx_t gtp5g_dev_xmit(struct sk_buff *skb, struct net_device *dev)
     if (ret < 0)
         goto tx_err;
 
-    if (ret == FAR_ACTION_FORW)
+    if (ret == PKT_FORWARDED)
         gtp5g_xmit_skb_ipv4(skb, &pktinfo);
 
     return NETDEV_TX_OK;


### PR DESCRIPTION
1. Add IE `source interface`.
2. Add a new API to retrieve statistical data from gtp5g.