### PR TITLE
Add support for setting PDU Session Container Type to UL

### DIFF
--- a/include/pktinfo.h
+++ b/include/pktinfo.h
@@ -13,6 +13,7 @@ struct gtp5g_pktinfo {
     struct rtable                 *rt;
     struct outer_header_creation  *hdr_creation;
     u8                            qfi;
+    u8                            pdu_type;
     u16                           seq_number;
     struct net_device             *dev;
     __be16                        gtph_port;
@@ -43,7 +44,7 @@ void gtp5g_xmit_skb_ipv4(struct sk_buff *, struct gtp5g_pktinfo *);
 void gtp5g_set_pktinfo_ipv4(struct gtp5g_pktinfo *,
         struct sock *, struct iphdr *,
         struct outer_header_creation *,
-        u8, u16, struct rtable *, struct flowi4 *,
+        u8, u8, u16, struct rtable *, struct flowi4 *,
         struct net_device *);
 void gtp5g_push_header(struct sk_buff *, struct gtp5g_pktinfo *);
 

--- a/src/genl/genl_far.c
+++ b/src/genl/genl_far.c
@@ -556,6 +556,7 @@ static int gtp5g_genl_fill_far(struct sk_buff *skb, u32 snd_portid, u32 snd_seq,
         if (nla_put_u64_64bit(skb, GTP5G_FAR_SEID, far->seid, 0))
             goto genlmsg_fail;
     }
+
     fwd_param = rcu_dereference(far->fwd_param);
     if (fwd_param) {
         nest_fwd_param = nla_nest_start(skb, GTP5G_FAR_FORWARDING_PARAMETER);

--- a/src/gtpu/encap.c
+++ b/src/gtpu/encap.c
@@ -931,6 +931,7 @@ static int gtp5g_fwd_skb_ipv4(struct sk_buff *skb,
     struct outer_header_creation *hdr_creation;
     u64 volume, volume_mbqe = 0;
     struct forwarding_parameter *fwd_param;
+    u8 pdu_type = PDU_SESSION_INFO_TYPE0;
 
     TrafficPolicer* tp = NULL;
     Color color = Green;
@@ -959,11 +960,16 @@ static int gtp5g_fwd_skb_ipv4(struct sk_buff *skb,
     if (IS_ERR(rt))
         goto err;
 
+    if (is_uplink(pdr)) {
+        pdu_type = PDU_SESSION_INFO_TYPE1;
+    }
+
     gtp5g_set_pktinfo_ipv4(pktinfo,
             pdr->sk, 
             iph, 
             hdr_creation,
-            pdr->qfi, 
+            pdr->qfi,
+            pdu_type,
             far->seq_number,
             rt, 
             &fl4, 


### PR DESCRIPTION
Add support for setting PDU Session Container Type to UL in the GTP-U Extension Header.

This is required for PacketRusher and I would like to avoid using a gtp5g fork inside PacketRusher, I think it's better if this kind of work can be upstreamed :-)

I stuffed the field in FAR as I think it was the better fit, but if you have any suggestions on a better place, please say so.
The location of the field is a breaking change as well, so we might need to move that.

The related go-gtp5nl PR: https://github.com/free5gc/go-gtp5gnl/pull/23

Thanks a lot!
Valentin