### PR TITLE
fix: support for compilation with linux v6.9

### DIFF
--- a/src/gtpu/pktinfo.c
+++ b/src/gtpu/pktinfo.c
@@ -74,7 +74,7 @@ struct rtable *ip4_find_route(struct sk_buff *skb, struct iphdr *iph,
     fl4->flowi4_oif = sk->sk_bound_dev_if;
     fl4->daddr = daddr;
     fl4->saddr = (saddr ? saddr : inet_sk(sk)->inet_saddr);
-    fl4->flowi4_tos = RT_CONN_FLAGS(sk);
+    fl4->flowi4_tos = RT_TOS(inet_sk(sk)->tos) | sock_flag(sk, SOCK_LOCALROUTE);
     fl4->flowi4_proto = sk->sk_protocol;
 
     rt = ip_route_output_key(dev_net(gtp_dev), fl4);
@@ -136,7 +136,7 @@ struct rtable *ip4_find_route_simple(struct sk_buff *skb,
     fl4->flowi4_oif = sk->sk_bound_dev_if;
     fl4->daddr = daddr;
     fl4->saddr = (saddr ? saddr : inet_sk(sk)->inet_saddr);
-    fl4->flowi4_tos = RT_CONN_FLAGS(sk);
+    fl4->flowi4_tos = RT_TOS(inet_sk(sk)->tos) | sock_flag(sk, SOCK_LOCALROUTE);
     fl4->flowi4_proto = sk->sk_protocol;
 
     rt = ip_route_output_key(dev_net(gtp_dev), fl4);


### PR DESCRIPTION
Linux v6.9 removed the RT_CONN_FLAGS macro, which causes the module to not compile anymore.
This is addressed my manually expanding the macro.

Closes https://github.com/free5gc/gtp5g/issues/109