### PR TITLE
Add udp_tunnel module to auto module load config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,4 +97,5 @@ uninstall:
 	rm -f $(DESTDIR)/lib/modules/$(KVER)/$(MOD_KERNEL_PATH)/$(MODULE_NAME).ko
 	$(DEPMOD)
 	rm -f /etc/modules-load.d/gtp5g.conf
+	rm -f /etc/modules-load.d/udp_tunnel.conf
 	rmmod -f  $(MODULE_NAME)

--- a/Makefile
+++ b/Makefile
@@ -88,14 +88,13 @@ clean:
 install:
 	$(INSTALL)
 	modprobe udp_tunnel
-	echo "udp_tunnel" > /etc/modules-load.d/udp_tunnel.conf
 	$(DEPMOD)
 	modprobe $(MODULE_NAME)
-	echo "gtp5g" > /etc/modules-load.d/gtp5g.conf
+	echo "udp_tunnel" > /etc/modules-load.d/gtp5g.conf
+	echo "gtp5g" >> /etc/modules-load.d/gtp5g.conf
 
 uninstall:
 	rm -f $(DESTDIR)/lib/modules/$(KVER)/$(MOD_KERNEL_PATH)/$(MODULE_NAME).ko
 	$(DEPMOD)
 	rm -f /etc/modules-load.d/gtp5g.conf
-	rm -f /etc/modules-load.d/udp_tunnel.conf
 	rmmod -f  $(MODULE_NAME)

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ clean:
 install:
 	$(INSTALL)
 	modprobe udp_tunnel
+	echo "udp_tunnel" > /etc/modules-load.d/udp_tunnel.conf
 	$(DEPMOD)
 	modprobe $(MODULE_NAME)
 	echo "gtp5g" > /etc/modules-load.d/gtp5g.conf


### PR DESCRIPTION
When running `make install` the udp_tunnel kernel module is not persisted which causes gtp5g module to not auto load on reboot. This patch fixes this issue.