### PR TITLE
fix: define NETIF_F_LLTX macro if missing

### DIFF
--- a/src/gtpu/link.c
+++ b/src/gtpu/link.c
@@ -11,6 +11,10 @@
 #include "log.h"
 #include "proc.h"
 
+#ifndef NETIF_F_LLTX
+#define NETIF_F_LLTX 0
+#endif
+
 const struct nla_policy gtp5g_policy[IFLA_GTP5G_MAX + 1] = {
     [IFLA_GTP5G_FD1]             = { .type = NLA_U32 },
     [IFLA_GTP5G_PDR_HASHSIZE]    = { .type = NLA_U32 },


### PR DESCRIPTION
In a recent kernel update the `NETIF_F_LLTX` was removed. It was deprecated for a long time and is replaced by a placeholder.

This results in the `NETIF_F_LLTX` being undefined and preventing the compilation under newer (`6.11.x` and `6.12.x`) kernel version.

If you have a better idea on how to do this e.g, by completely removing the line using `NETIF_F_LLTX` I am open for changes.

Cheers,
Julian