### PR TITLE
Fix downlink GTP packets not being forwarded when `ue_addr_ipv4` is set

### DIFF
--- a/src/pfcp/pdr.c
+++ b/src/pfcp/pdr.c
@@ -262,6 +262,7 @@ struct pdr *pdr_find_by_gtp1u(struct gtp5g_dev *gtp, struct sk_buff *skb,
 #endif
     struct iphdr *iph;
     __be32 *target_addr = NULL;
+    __be32 *source_addr = NULL;
     struct hlist_head *head;
     struct pdr *pdr;
     struct pdi *pdi;
@@ -277,6 +278,7 @@ struct pdr *pdr_find_by_gtp1u(struct gtp5g_dev *gtp, struct sk_buff *skb,
             return NULL;
         iph = (struct iphdr *)(skb->data + hdrlen);
         target_addr = (gtp->role == GTP5G_ROLE_UPF ? &iph->saddr : &iph->daddr);
+        source_addr = (gtp->role == GTP5G_ROLE_UPF ? &iph->daddr : &iph->saddr);
     }
 
     head = &gtp->i_teid_hash[u32_hashfn(teid) % gtp->hash_size];
@@ -305,7 +307,9 @@ struct pdr *pdr_find_by_gtp1u(struct gtp5g_dev *gtp, struct sk_buff *skb,
     #endif
 #endif
         if (pdi->ue_addr_ipv4)
-            if (!(pdr->af == AF_INET && target_addr && *target_addr == pdi->ue_addr_ipv4->s_addr))
+            if ((!(pdr->af == AF_INET)) || (
+                (!(target_addr && *target_addr == pdi->ue_addr_ipv4->s_addr)) &&
+                (!(source_addr && *source_addr == pdi->ue_addr_ipv4->s_addr))))
                 continue;
 
         if (pdi->sdf)


### PR DESCRIPTION
According to TS 129.244 Table 7.5.2.2-2: PDI IE within PFCP Session Establishment Request:

> UE IP address: If present, this IE shall identify the UE IP address
> as the source **or destination IP address** to match for the incoming packet.

When `gtp.role == GTP5G_ROLE_UPF`, only the source address was checked. This resulted in dropping downlink GTP packets when UE IP address IE was set.

This bug makes freeGC's go-upf incompatible with some third party SMFs.

To reproduce the bug:
1. setup a free5GC network with an UPF-I and an UPF-A.
2. start pinging the Data Network from the UE
3. use `gtp5g-tunnel` to edit the downlink pdr by adding the UE IP address on the downlink PDR.
4. Without this PR, ICMP responses are no longer received from the UE because the UPF-i is dropping related GTP packets.

When merged, this will allow
https://github.com/free5gc/smf/blob/d049a7aa51db56cb2fad33713e422deac77ee2eb/internal/context/datapath.go#L636-L640 to be uncommented on free5GC's SMF. This also probably resolves the related FR5GC-1029 issue (but I don't have access to issue details, so I'm not sure).