### PR TITLE
Update URR report

### DIFF
--- a/include/genl_report.h
+++ b/include/genl_report.h
@@ -62,5 +62,5 @@ int gtp5g_genl_fill_ur(struct sk_buff *, struct usage_report *);
 int gtp5g_genl_fill_usage_report(struct sk_buff *, u32, u32, u32, struct usage_report *);
 int gtp5g_genl_fill_multi_usage_reports(struct sk_buff *, u32, u32, u32, struct usage_report **, u32);
 
-void convert_urr_to_report(struct urr *, struct usage_report *);
+void convert_urr_to_report(struct urr *, struct usage_report *, bool);
 #endif // __GENL_URR_H__

--- a/include/genl_report.h
+++ b/include/genl_report.h
@@ -62,5 +62,5 @@ int gtp5g_genl_fill_ur(struct sk_buff *, struct usage_report *);
 int gtp5g_genl_fill_usage_report(struct sk_buff *, u32, u32, u32, struct usage_report *);
 int gtp5g_genl_fill_multi_usage_reports(struct sk_buff *, u32, u32, u32, struct usage_report **, u32);
 
-void convert_urr_to_report(struct urr *, struct usage_report *, bool);
+void convert_urr_to_report(struct urr *urr, struct VolumeMeasurement *, struct usage_report *);
 #endif // __GENL_URR_H__

--- a/include/urr.h
+++ b/include/urr.h
@@ -79,6 +79,7 @@ struct urr {
     struct Volume volumequota;
 
     // For usage report volume measurement
+    bool use_bytes2;
     struct VolumeMeasurement bytes;
     struct VolumeMeasurement bytes2;
     struct VolumeMeasurement consumed;

--- a/include/urr.h
+++ b/include/urr.h
@@ -80,7 +80,7 @@ struct urr {
 
     // For usage report volume measurement
     // TRIGGER_PERIO
-    spinlock_t period_report_counter_lock;
+    spinlock_t period_vol_counter_lock;
     bool use_vol2;
     struct VolumeMeasurement vol1;
     struct VolumeMeasurement vol2;
@@ -115,6 +115,6 @@ void urr_append(u64, u32, struct urr *, struct gtp5g_dev *);
 int urr_get_pdr_ids(u16 *, int, struct urr *, struct gtp5g_dev *);
 int urr_set_pdr(struct pdr *, struct gtp5g_dev *);
 void del_related_urr_hash(struct gtp5g_dev *, struct pdr *);
-struct VolumeMeasurement *get_period_report_counter(struct urr *, bool);
-void change_current_period_counter_for_writer(struct urr *);
+struct VolumeMeasurement *get_period_vol_counter(struct urr *, bool);
+struct VolumeMeasurement *get_and_switch_period_vol_counter(struct urr *);
 #endif // __URR_H__

--- a/include/urr.h
+++ b/include/urr.h
@@ -79,9 +79,9 @@ struct urr {
     struct Volume volumequota;
 
     // For usage report volume measurement
-    bool use_bytes2;
-    struct VolumeMeasurement bytes;
-    struct VolumeMeasurement bytes2;
+    bool use_vol2;
+    struct VolumeMeasurement vol;
+    struct VolumeMeasurement vol2;
     struct VolumeMeasurement consumed;
 
     // for report time

--- a/include/urr.h
+++ b/include/urr.h
@@ -79,10 +79,15 @@ struct urr {
     struct Volume volumequota;
 
     // For usage report volume measurement
+    // TRIGGER_PERIO
+    spinlock_t period_report_counter_lock;
     bool use_vol2;
-    struct VolumeMeasurement vol;
+    struct VolumeMeasurement vol1;
     struct VolumeMeasurement vol2;
+    // TRIGGER_VOLQU
     struct VolumeMeasurement consumed;
+    // TRIGGER_VOLTH
+    struct VolumeMeasurement threshold;
 
     // for report time
     ktime_t start_time;
@@ -110,6 +115,6 @@ void urr_append(u64, u32, struct urr *, struct gtp5g_dev *);
 int urr_get_pdr_ids(u16 *, int, struct urr *, struct gtp5g_dev *);
 int urr_set_pdr(struct pdr *, struct gtp5g_dev *);
 void del_related_urr_hash(struct gtp5g_dev *, struct pdr *);
-struct VolumeMeasurement *get_usage_report_counter(struct urr *, bool);
-
+struct VolumeMeasurement *get_period_report_counter(struct urr *, bool);
+void change_current_period_counter_for_writer(struct urr *);
 #endif // __URR_H__

--- a/include/urr.h
+++ b/include/urr.h
@@ -85,9 +85,9 @@ struct urr {
     struct VolumeMeasurement vol1;
     struct VolumeMeasurement vol2;
     // TRIGGER_VOLQU
-    struct VolumeMeasurement consumed;
+    struct VolumeMeasurement vol_qu;
     // TRIGGER_VOLTH
-    struct VolumeMeasurement threshold;
+    struct VolumeMeasurement vol_th;
 
     // for report time
     ktime_t start_time;

--- a/src/genl/genl_report.c
+++ b/src/genl/genl_report.c
@@ -160,9 +160,7 @@ int gtp5g_genl_get_usage_report(struct sk_buff *skb, struct genl_info *info)
 
     // set the use_vol2 flag to the opposite value
     urr->use_vol2 = !urr->use_vol2;
-    // sleep for 1 millisecond to make sure the counter is updated
-    // before converting to the report
-    msleep(1);
+
     report = kzalloc(sizeof(struct usage_report), GFP_KERNEL);
     if (!report) {
         err = -ENOMEM;
@@ -256,9 +254,7 @@ int gtp5g_genl_get_multi_usage_reports(struct sk_buff *skb, struct genl_info *in
 
         // set the use_vol2 flag to the opposite value
         urr->use_vol2 = !urr->use_vol2;
-        // sleep for 1 millisecond to make sure the counter is updated
-        // before converting to the report
-        msleep(1);
+
         reports[i] = kzalloc(sizeof(struct usage_report), GFP_KERNEL);
         if (!reports[i]) {
             err =  -ENOMEM;

--- a/src/genl/genl_report.c
+++ b/src/genl/genl_report.c
@@ -159,12 +159,7 @@ int gtp5g_genl_get_usage_report(struct sk_buff *skb, struct genl_info *info)
         goto fail;
     }
 
-    urr_counter = get_period_report_counter(urr, urr->use_vol2);
-    // use the other one vol counter
-    spin_lock(&urr->period_report_counter_lock);
-    change_current_period_counter_for_writer(urr);
-    spin_unlock(&urr->period_report_counter_lock);
-
+    urr_counter = get_and_switch_period_vol_counter(urr);
     report = kzalloc(sizeof(struct usage_report), GFP_KERNEL);
     if (!report) {
         err = -ENOMEM;
@@ -257,12 +252,7 @@ int gtp5g_genl_get_multi_usage_reports(struct sk_buff *skb, struct genl_info *in
             goto fail;
         }
 
-        urr_counter = get_period_report_counter(urr, urr->use_vol2);
-        // use the other one vol counter
-        spin_lock(&urr->period_report_counter_lock);
-        change_current_period_counter_for_writer(urr);
-        spin_unlock(&urr->period_report_counter_lock);
-
+        urr_counter = get_and_switch_period_vol_counter(urr);
         reports[i] = kzalloc(sizeof(struct usage_report), GFP_KERNEL);
         if (!reports[i]) {
             err =  -ENOMEM;

--- a/src/genl/genl_urr.c
+++ b/src/genl/genl_urr.c
@@ -93,6 +93,7 @@ int gtp5g_genl_add_urr(struct sk_buff *skb, struct genl_info *info)
         goto end;
     }
 
+    spin_lock_init(&urr->period_report_counter_lock);
     urr->dev = gtp->dev;
     urr->start_time = ktime_get_real();
 
@@ -121,7 +122,7 @@ int gtp5g_genl_del_urr(struct sk_buff *skb, struct genl_info *info)
     struct sk_buff *skb_ack = NULL;
     int err = 0;
     struct usage_report *report = NULL;
-
+    struct VolumeMeasurement *urr_counter = NULL;
     if (!info->attrs[GTP5G_LINK])
         return -EINVAL;
     ifindex = nla_get_u32(info->attrs[GTP5G_LINK]);
@@ -169,8 +170,9 @@ int gtp5g_genl_del_urr(struct sk_buff *skb, struct genl_info *info)
         goto fail;
     }
 
+    urr_counter = get_period_report_counter(urr, urr->use_vol2);
     // return current counter
-    convert_urr_to_report(urr, report, urr->use_vol2);
+    convert_urr_to_report(urr, urr_counter, report);
 
     err = gtp5g_genl_fill_usage_report(skb_ack,
             NETLINK_CB(skb).portid,
@@ -335,7 +337,7 @@ static int urr_fill(struct urr *urr, struct gtp5g_dev *gtp, struct genl_info *in
         if (urr->trigger == URR_RPT_TRIGGER_START) {
             // Clean vol to make sure the vol are counted after the start of service data flow
             // TODO: Should send the previous stroed vol to CP first
-            memset(&urr->vol, 0, sizeof(struct VolumeMeasurement));
+            memset(&urr->vol1, 0, sizeof(struct VolumeMeasurement));
             memset(&urr->vol2, 0, sizeof(struct VolumeMeasurement));
         }
     }

--- a/src/genl/genl_urr.c
+++ b/src/genl/genl_urr.c
@@ -169,7 +169,8 @@ int gtp5g_genl_del_urr(struct sk_buff *skb, struct genl_info *info)
         goto fail;
     }
 
-    convert_urr_to_report(urr, report);
+    // return current counter
+    convert_urr_to_report(urr, report, urr->use_bytes2);
 
     err = gtp5g_genl_fill_usage_report(skb_ack,
             NETLINK_CB(skb).portid,

--- a/src/genl/genl_urr.c
+++ b/src/genl/genl_urr.c
@@ -343,7 +343,7 @@ static int urr_fill(struct urr *urr, struct gtp5g_dev *gtp, struct genl_info *in
             memset(&urr->vol1, 0, sizeof(struct VolumeMeasurement));
             memset(&urr->vol2, 0, sizeof(struct VolumeMeasurement));
             // Clear the threshold report counter.
-            memset(&urr->threshold, 0, sizeof(struct VolumeMeasurement));
+            memset(&urr->vol_th, 0, sizeof(struct VolumeMeasurement));
         }
     }
 
@@ -361,7 +361,7 @@ static int urr_fill(struct urr *urr, struct gtp5g_dev *gtp, struct genl_info *in
 
     if (info->attrs[GTP5G_URR_VOLUME_QUOTA]) {
         parse_volumeqouta(urr, info->attrs[GTP5G_URR_VOLUME_QUOTA]);
-        memset(&urr->consumed, 0, sizeof(struct VolumeMeasurement));
+        memset(&urr->vol_qu, 0, sizeof(struct VolumeMeasurement));
 
         if (urr->volumequota.totalVolume == 0 && (urr->trigger & URR_RPT_TRIGGER_VOLQU)) {
             urr_quota_exhaust_action(urr, gtp);

--- a/src/genl/genl_urr.c
+++ b/src/genl/genl_urr.c
@@ -323,17 +323,20 @@ static int urr_fill(struct urr *urr, struct gtp5g_dev *gtp, struct genl_info *in
 {
     urr->id = nla_get_u32(info->attrs[GTP5G_URR_ID]);
 
-    if (info->attrs[GTP5G_URR_SEID])
+    if (info->attrs[GTP5G_URR_SEID]) {
         urr->seid = nla_get_u64(info->attrs[GTP5G_URR_SEID]);
-    else
+    }
+    else {
         urr->seid = 0;
+    }
 
-    if (info->attrs[GTP5G_URR_MEASUREMENT_METHOD])
+    if (info->attrs[GTP5G_URR_MEASUREMENT_METHOD]) {
         urr->method = nla_get_u8(info->attrs[GTP5G_URR_MEASUREMENT_METHOD]);
+    }
 
     if (info->attrs[GTP5G_URR_REPORTING_TRIGGER]) {
         urr->trigger = nla_get_u32(info->attrs[GTP5G_URR_REPORTING_TRIGGER]);
-        if (urr->trigger == URR_RPT_TRIGGER_START) {
+        if (urr->trigger & URR_RPT_TRIGGER_START) {
             // Clean vol to make sure the vol are counted after the start of service data flow
             // TODO: Should send the previous stroed vol to CP first
             memset(&urr->vol1, 0, sizeof(struct VolumeMeasurement));
@@ -341,20 +344,23 @@ static int urr_fill(struct urr *urr, struct gtp5g_dev *gtp, struct genl_info *in
         }
     }
 
-    if (info->attrs[GTP5G_URR_MEASUREMENT_PERIOD])
+    if (info->attrs[GTP5G_URR_MEASUREMENT_PERIOD]) {
         urr->period = nla_get_u32(info->attrs[GTP5G_URR_MEASUREMENT_PERIOD]);
+    }
 
-    if (info->attrs[GTP5G_URR_MEASUREMENT_INFO])
+    if (info->attrs[GTP5G_URR_MEASUREMENT_INFO]) {
         urr->info = nla_get_u8(info->attrs[GTP5G_URR_MEASUREMENT_INFO]);
+    }
 
-    if (info->attrs[GTP5G_URR_VOLUME_THRESHOLD])
+    if (info->attrs[GTP5G_URR_VOLUME_THRESHOLD]) {
         parse_volumethreshold(urr, info->attrs[GTP5G_URR_VOLUME_THRESHOLD]);
+    }
 
     if (info->attrs[GTP5G_URR_VOLUME_QUOTA]) {
         parse_volumeqouta(urr, info->attrs[GTP5G_URR_VOLUME_QUOTA]);
         memset(&urr->consumed, 0, sizeof(struct VolumeMeasurement));
 
-        if (urr->volumequota.totalVolume == 0 && urr->trigger == URR_RPT_TRIGGER_VOLQU) {
+        if (urr->volumequota.totalVolume == 0 && (urr->trigger & URR_RPT_TRIGGER_VOLQU)) {
             urr_quota_exhaust_action(urr, gtp);
             GTP5G_INF(NULL, "URR (%u) Receive zero quota, stop measure", urr->id);
         } else if (urr->quota_exhausted) {

--- a/src/genl/genl_urr.c
+++ b/src/genl/genl_urr.c
@@ -339,8 +339,11 @@ static int urr_fill(struct urr *urr, struct gtp5g_dev *gtp, struct genl_info *in
         if (urr->trigger & URR_RPT_TRIGGER_START) {
             // Clean vol to make sure the vol are counted after the start of service data flow
             // TODO: Should send the previous stroed vol to CP first
+            // Clear periodic report counters vol1 and vol2.
             memset(&urr->vol1, 0, sizeof(struct VolumeMeasurement));
             memset(&urr->vol2, 0, sizeof(struct VolumeMeasurement));
+            // Clear the threshold report counter.
+            memset(&urr->threshold, 0, sizeof(struct VolumeMeasurement));
         }
     }
 

--- a/src/genl/genl_urr.c
+++ b/src/genl/genl_urr.c
@@ -170,7 +170,7 @@ int gtp5g_genl_del_urr(struct sk_buff *skb, struct genl_info *info)
     }
 
     // return current counter
-    convert_urr_to_report(urr, report, urr->use_bytes2);
+    convert_urr_to_report(urr, report, urr->use_vol2);
 
     err = gtp5g_genl_fill_usage_report(skb_ack,
             NETLINK_CB(skb).portid,
@@ -333,10 +333,10 @@ static int urr_fill(struct urr *urr, struct gtp5g_dev *gtp, struct genl_info *in
     if (info->attrs[GTP5G_URR_REPORTING_TRIGGER]) {
         urr->trigger = nla_get_u32(info->attrs[GTP5G_URR_REPORTING_TRIGGER]);
         if (urr->trigger == URR_RPT_TRIGGER_START) {
-            // Clean bytes to make sure the bytes are counted after the start of service data flow
-            // TODO: Should send the previous stroed bytes to CP first
-            memset(&urr->bytes, 0, sizeof(struct VolumeMeasurement));
-            memset(&urr->bytes2, 0, sizeof(struct VolumeMeasurement));
+            // Clean vol to make sure the vol are counted after the start of service data flow
+            // TODO: Should send the previous stroed vol to CP first
+            memset(&urr->vol, 0, sizeof(struct VolumeMeasurement));
+            memset(&urr->vol2, 0, sizeof(struct VolumeMeasurement));
         }
     }
 

--- a/src/genl/genl_urr.c
+++ b/src/genl/genl_urr.c
@@ -93,7 +93,7 @@ int gtp5g_genl_add_urr(struct sk_buff *skb, struct genl_info *info)
         goto end;
     }
 
-    spin_lock_init(&urr->period_report_counter_lock);
+    spin_lock_init(&urr->period_vol_counter_lock);
     urr->dev = gtp->dev;
     urr->start_time = ktime_get_real();
 
@@ -170,8 +170,7 @@ int gtp5g_genl_del_urr(struct sk_buff *skb, struct genl_info *info)
         goto fail;
     }
 
-    urr_counter = get_period_report_counter(urr, urr->use_vol2);
-    // return current counter
+    urr_counter = get_period_vol_counter(urr, urr->use_vol2);
     convert_urr_to_report(urr, urr_counter, report);
 
     err = gtp5g_genl_fill_usage_report(skb_ack,

--- a/src/gtpu/encap.c
+++ b/src/gtpu/encap.c
@@ -611,11 +611,12 @@ static struct VolumeMeasurement *get_urr_counter_by_trigger(struct urr *urr, u32
     if (!urr)
         return NULL;
 
-    if (trigger == URR_RPT_TRIGGER_VOLTH)
+    if (trigger & URR_RPT_TRIGGER_VOLTH) {
         return &urr->threshold;
-    else if (trigger == URR_RPT_TRIGGER_VOLQU)
+    }
+    else if (trigger & URR_RPT_TRIGGER_VOLQU) {
         return &urr->consumed;
-
+    }
     return NULL;
 }
 
@@ -675,7 +676,7 @@ int update_urr_counter_and_send_report(struct pdr *pdr, struct far *far, u64 vol
                     goto err1;
                 }
 
-                if (urr->trigger & URR_RPT_TRIGGER_START && uplink) {
+                if ((urr->trigger & URR_RPT_TRIGGER_START) && uplink) {
                     triggers[report_num] = USAR_TRIGGER_START;
                     urrs[report_num++] = urr;
                     urr_quota_exhaust_action(urr, gtp);
@@ -700,6 +701,7 @@ int update_urr_counter_and_send_report(struct pdr *pdr, struct far *far, u64 vol
                     if (urr->period == 0) {
                         continue;
                     }
+		    // update period vol counter
                     spin_lock(&urr->period_vol_counter_lock);
                     urr_counter = get_period_vol_counter(urr, urr->use_vol2);
                     update_counter(urr_counter, volume, uplink, mnop);

--- a/src/gtpu/encap.c
+++ b/src/gtpu/encap.c
@@ -672,14 +672,14 @@ int update_urr_counter_and_send_report(struct pdr *pdr, struct far *far, u64 vol
                 }
 
                 // Caculate Volume measurement for each trigger
-                urr_counter = get_usage_report_counter(urr, urr->use_bytes2);
+                urr_counter = get_usage_report_counter(urr, urr->use_vol2);
                 if (urr->trigger & URR_RPT_TRIGGER_VOLTH) {
                     if (increment_and_check_counter(urr_counter, &urr->volumethreshold, volume, uplink, mnop)) {
                         triggers[report_num] = USAR_TRIGGER_VOLTH;
                         urrs[report_num++] = urr;
                     }
                 } else {
-                    // For other triggers, only increment bytes
+                    // For other triggers, only increment vol
                     increment_and_check_counter(urr_counter, NULL, volume, uplink, mnop);
                 }
                 if (urr->trigger & URR_RPT_TRIGGER_VOLQU) {
@@ -709,7 +709,7 @@ int update_urr_counter_and_send_report(struct pdr *pdr, struct far *far, u64 vol
             if (triggers[i] == USAR_TRIGGER_START){
                 ret = DONT_SEND_UL_PACKET;
             }                 
-            convert_urr_to_report(urrs[i], &report[i], !urrs[i]->use_bytes2);
+            convert_urr_to_report(urrs[i], &report[i], !urrs[i]->use_vol2);
 
             report[i].trigger = triggers[i];
         }

--- a/src/gtpu/encap.c
+++ b/src/gtpu/encap.c
@@ -700,10 +700,10 @@ int update_urr_counter_and_send_report(struct pdr *pdr, struct far *far, u64 vol
                     if (urr->period == 0) {
                         continue;
                     }
-                    spin_lock(&urr->period_report_counter_lock);
-                    urr_counter = get_period_report_counter(urr, urr->use_vol2);
+                    spin_lock(&urr->period_vol_counter_lock);
+                    urr_counter = get_period_vol_counter(urr, urr->use_vol2);
                     update_counter(urr_counter, volume, uplink, mnop);
-                    spin_unlock(&urr->period_report_counter_lock);
+                    spin_unlock(&urr->period_vol_counter_lock);
                 }
                 if (urr->trigger & URR_RPT_TRIGGER_VOLQU) {
                     update_counter(&urr->consumed, volume, uplink, mnop);

--- a/src/gtpu/encap.c
+++ b/src/gtpu/encap.c
@@ -670,8 +670,9 @@ int update_urr_counter_and_send_report(struct pdr *pdr, struct far *far, u64 vol
                 } else {
                     volume = vol;
                 }
+
                 // Caculate Volume measurement for each trigger
-                urr_counter = get_usage_report_counter(urr, false);
+                urr_counter = get_usage_report_counter(urr, urr->use_bytes2);
                 if (urr->trigger & URR_RPT_TRIGGER_VOLTH) {
                     if (increment_and_check_counter(urr_counter, &urr->volumethreshold, volume, uplink, mnop)) {
                         triggers[report_num] = USAR_TRIGGER_VOLTH;
@@ -708,7 +709,7 @@ int update_urr_counter_and_send_report(struct pdr *pdr, struct far *far, u64 vol
             if (triggers[i] == USAR_TRIGGER_START){
                 ret = DONT_SEND_UL_PACKET;
             }                 
-            convert_urr_to_report(urrs[i], &report[i]);
+            convert_urr_to_report(urrs[i], &report[i], !urrs[i]->use_bytes2);
 
             report[i].trigger = triggers[i];
         }

--- a/src/gtpu/encap.c
+++ b/src/gtpu/encap.c
@@ -560,13 +560,13 @@ static int unix_sock_send(struct pdr *pdr, struct far *far, void *buf, u32 len, 
     return rt;
 }
 
-bool increment_and_check_counter(struct VolumeMeasurement *volmeasure, struct Volume *volume, u64 vol, bool uplink, bool mnop){
+void update_counter(struct VolumeMeasurement *volmeasure, u64 vol, bool uplink, bool mnop){
     if (!volmeasure) {
-        return false;
+        return;
     }
 
     if (vol == 0) {
-        return false;
+        return;
     }
 
     if (mnop) {
@@ -585,6 +585,12 @@ bool increment_and_check_counter(struct VolumeMeasurement *volmeasure, struct Vo
     }
 
     volmeasure->totalVolume = volmeasure->uplinkVolume + volmeasure->downlinkVolume;
+}
+
+bool check_counter(struct VolumeMeasurement *volmeasure, struct Volume *volume){
+    if (!volmeasure) {
+        return false;
+    }
 
     if (!volume) {
         return false;
@@ -599,6 +605,18 @@ bool increment_and_check_counter(struct VolumeMeasurement *volmeasure, struct Vo
     }
 
     return false;
+}
+
+static struct VolumeMeasurement *get_urr_counter_by_trigger(struct urr *urr, u32 trigger) {
+    if (!urr)
+        return NULL;
+
+    if (trigger == URR_RPT_TRIGGER_VOLTH)
+        return &urr->threshold;
+    else if (trigger == URR_RPT_TRIGGER_VOLQU)
+        return &urr->consumed;
+
+    return NULL;
 }
 
 int update_urr_counter_and_send_report(struct pdr *pdr, struct far *far, u64 vol, u64 vol_mbqe) {
@@ -671,19 +689,25 @@ int update_urr_counter_and_send_report(struct pdr *pdr, struct far *far, u64 vol
                     volume = vol;
                 }
 
-                // Caculate Volume measurement for each trigger
-                urr_counter = get_usage_report_counter(urr, urr->use_vol2);
+                // Calculate Volume measurement for each trigger
                 if (urr->trigger & URR_RPT_TRIGGER_VOLTH) {
-                    if (increment_and_check_counter(urr_counter, &urr->volumethreshold, volume, uplink, mnop)) {
+                    update_counter(&urr->threshold, volume, uplink, mnop);
+                    if (check_counter(&urr->threshold, &urr->volumethreshold)) {
                         triggers[report_num] = USAR_TRIGGER_VOLTH;
                         urrs[report_num++] = urr;
                     }
                 } else {
-                    // For other triggers, only increment vol
-                    increment_and_check_counter(urr_counter, NULL, volume, uplink, mnop);
+                    if (urr->period == 0) {
+                        continue;
+                    }
+                    spin_lock(&urr->period_report_counter_lock);
+                    urr_counter = get_period_report_counter(urr, urr->use_vol2);
+                    update_counter(urr_counter, volume, uplink, mnop);
+                    spin_unlock(&urr->period_report_counter_lock);
                 }
                 if (urr->trigger & URR_RPT_TRIGGER_VOLQU) {
-                    if (increment_and_check_counter(&urr->consumed, &urr->volumequota, volume, uplink, mnop)) {
+                    update_counter(&urr->consumed, volume, uplink, mnop);
+                    if (check_counter(&urr->consumed, &urr->volumequota)) {
                         triggers[report_num] = USAR_TRIGGER_VOLQU;
                         urrs[report_num++] = urr;
                         urr_quota_exhaust_action(urr, gtp);
@@ -708,8 +732,9 @@ int update_urr_counter_and_send_report(struct pdr *pdr, struct far *far, u64 vol
             // TODO: FAR ID for Quota Action IE for indicating the action while no quota is granted
             if (triggers[i] == USAR_TRIGGER_START){
                 ret = DONT_SEND_UL_PACKET;
-            }                 
-            convert_urr_to_report(urrs[i], &report[i], !urrs[i]->use_vol2);
+            } 
+            urr_counter = get_urr_counter_by_trigger(urrs[i], triggers[i]);                
+            convert_urr_to_report(urr, urr_counter, &report[i]);
 
             report[i].trigger = triggers[i];
         }

--- a/src/pfcp/urr.c
+++ b/src/pfcp/urr.c
@@ -257,24 +257,24 @@ int urr_set_pdr(struct pdr *pdr, struct gtp5g_dev *gtp)
 /* 
  `get_usage_report_counter` will return one of the two counters.
  
- To avoid sending incorrect reports, there are two counters (vol, vol2) for each period.
+ To avoid sending incorrect reports, there are two counters (vol1, vol2) for each period.
  These counters will take turns recording the packet count.
  
  For usage report => counter of the previous period
  For packet counting => counter of the current period 
 */  
-struct VolumeMeasurement *get_usage_report_counter(struct urr *urr, bool use_vol2)
+struct VolumeMeasurement *get_period_report_counter(struct urr *urr, bool use_vol2)
 {
-    // If the period is zero, always return the first counter.
-    if (urr->period == 0) {
-       return &urr->vol; 
-    }
-
     if (use_vol2) {
         return &urr->vol2;
     } else{
-        return &urr->vol;
+        return &urr->vol1;
     } 
 
-    return &urr->vol;
+    return &urr->vol1;
+}
+
+void change_current_period_counter_for_writer(struct urr *urr)
+{
+    urr->use_vol2 = !urr->use_vol2;
 }

--- a/src/pfcp/urr.c
+++ b/src/pfcp/urr.c
@@ -257,24 +257,24 @@ int urr_set_pdr(struct pdr *pdr, struct gtp5g_dev *gtp)
 /* 
  `get_usage_report_counter` will return one of the two counters.
  
- To avoid sending incorrect reports, there are two counters (bytes, bytes2) for each period.
+ To avoid sending incorrect reports, there are two counters (vol, vol2) for each period.
  These counters will take turns recording the packet count.
  
  For usage report => counter of the previous period
  For packet counting => counter of the current period 
 */  
-struct VolumeMeasurement *get_usage_report_counter(struct urr *urr, bool use_bytes2)
+struct VolumeMeasurement *get_usage_report_counter(struct urr *urr, bool use_vol2)
 {
     // If the period is zero, always return the first counter.
     if (urr->period == 0) {
-       return &urr->bytes; 
+       return &urr->vol; 
     }
 
-    if (use_bytes2) {
-        return &urr->bytes2;
+    if (use_vol2) {
+        return &urr->vol2;
     } else{
-        return &urr->bytes;
+        return &urr->vol;
     } 
 
-    return &urr->bytes;
+    return &urr->vol;
 }

--- a/src/pfcp/urr.c
+++ b/src/pfcp/urr.c
@@ -263,28 +263,18 @@ int urr_set_pdr(struct pdr *pdr, struct gtp5g_dev *gtp)
  For usage report => counter of the previous period
  For packet counting => counter of the current period 
 */  
-struct VolumeMeasurement *get_usage_report_counter(struct urr *urr, bool previous_counter)
+struct VolumeMeasurement *get_usage_report_counter(struct urr *urr, bool use_bytes2)
 {
-    u32 now = ktime_get_real() / NSEC_PER_SEC;
-
     // If the period is zero, always return the first counter.
     if (urr->period == 0) {
        return &urr->bytes; 
     }
 
-    if ((now/urr->period)%2 == 1) {
-        if (previous_counter) {
-            return &urr->bytes;
-        } else{
-            return &urr->bytes2;
-        } 
-    } else {
-        if (previous_counter) {
-            return &urr->bytes2;
-        } else{
-            return &urr->bytes;
-        } 
-    }
+    if (use_bytes2) {
+        return &urr->bytes2;
+    } else{
+        return &urr->bytes;
+    } 
 
     return &urr->bytes;
 }


### PR DESCRIPTION
Refactor period counter statistics and reading mechanism to ensure data consistency

Changes:
- Reader
  1. Update the table that the writer will write to (opposite to the one being read).
  2. Read data.

- Writer
  1. Acquire the target table for writing.
  2. Write data.

Locking mechanism adjustments:
- Reader lock scope:
  - Lock is held while updating the writer's target table and released immediately after, allowing the reader to read the current table freely.

- Writer lock scope:
  - Lock is held while acquiring the target table and writing data.
  - Ensures consistency between packet count and packet volume, preventing a scenario where packet count is updated but packet volume remains stale before the reader fetches the data.