### PR TITLE
update: change window size to 1000ms, set size of ebs to the same of cbs

### DIFF
--- a/src/gtpu/trTCM.c
+++ b/src/gtpu/trTCM.c
@@ -20,13 +20,13 @@ TrafficPolicer* newTrafficPolicer(u64 kbitRate) {
     
     p->byteRate = kbitRate * 125 ; // Kbit/s to byte/s (*1000/8)
 
-    // 8ms as burst size
-    p->cbs = p->byteRate * 8 / MILLISECONDS_PER_SECOND; // bytes
+    // 1000ms as burst size
+    p->cbs = p->byteRate * 1000 / MILLISECONDS_PER_SECOND; // bytes
     if (p->cbs < MTU) {
         p->cbs = MTU;
     }
 
-    p->ebs = p->cbs * 2; // bytes, 2 times of cbs size
+    p->ebs = p->cbs * 1; // bytes, 1 times of cbs size
 
     // fill buckets at the begining
     p->tc = p->cbs; 


### PR DESCRIPTION
- Set to 1000ms can get normal throughput (~10.1 Mbps) when testing Session-AMBR (configured value of UL is 10Mbps) UDP UL with 800Mbps sender rate.
![15_UDP_Pega_qos_enabled_gtp5g_1000_1_granuity_1sec](https://github.com/user-attachments/assets/d4064bd9-8510-43f9-a5f0-61d6aa11c2a9)

- However, this change may cause the configured Session-AMBR UL value to be exceeded. We should change algorithm in future.