### PR TITLE
Fix build on Linux kernel 6.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 RHEL8 := $(shell cat /etc/redhat-release 2>/dev/null | grep -c " 8." )
 ifneq (,$(findstring 1, $(RHEL8)))
 	RHEL8FLAG := -DRHEL8
@@ -35,10 +34,10 @@ endif
 
 MY_CFLAGS += -g -DDEBUG $(RHEL8FLAG)
 # MY_CFLAGS += -DMATCH_IP # match IP address(in F-TEID) or not
-EXTRA_CFLAGS += -Wno-misleading-indentation -Wuninitialized
+ccflags-y += -Wno-misleading-indentation -Wuninitialized
 CC += ${MY_CFLAGS}
 
-EXTRA_CFLAGS += -I $(MAKEFILE_DIR)/include
+ccflags-y += -I $(MAKEFILE_DIR)/include
 
 5G_MOD := src/gtp5g.o
 

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,7 +1,6 @@
 PACKAGE_NAME="gtp5g"
 PACKAGE_VERSION="0.9.14"
 
-CLEAN="make clean KVER=$kernelver"
 MAKE="make KVER=$kernelver"
 
 BUILT_MODULE_NAME="gtp5g"

--- a/src/gtpu/link.c
+++ b/src/gtpu/link.c
@@ -1,3 +1,4 @@
+#include <linux/version.h>
 #include <net/rtnetlink.h>
 #include <net/ip.h>
 #include <net/udp.h>
@@ -59,10 +60,20 @@ static int gtp5g_validate(struct nlattr *tb[], struct nlattr *data[],
     return 0;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,15,0)
+static int gtp5g_newlink(struct net_device *dev,
+    struct rtnl_newlink_params *params,
+    struct netlink_ext_ack *extack)
+#else
 static int gtp5g_newlink(struct net *src_net, struct net_device *dev,
     struct nlattr *tb[], struct nlattr *data[],
     struct netlink_ext_ack *extack)
+#endif
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,15,0)
+    struct nlattr **data;
+    data = params->data;
+#endif
     struct gtp5g_dev *gtp;
     struct gtp5g_net *gn;
     struct sock *sk;


### PR DESCRIPTION
When updating my kernel to `6.15` I realized I could not build `gtp5g` anymore.

So I did the following three things to fix this:
1. Removed the `CLEAN` entry because it defaults to `make clean` anyways. In a recent update the `CLEAN` entry got deprecated. This change is optional I think because it is only a warning. 
2. Replaced the deprecated `EXTRA_CFLAGS` by `ccflags-y`. This change is necessary because otherwise the the includes inside the `Makefile` are not found. Also `EXTRA_CFLAGS` got deprecated more than 13 years ago so I think it's safe to replace it.
3. Adjusted the parameters of the `gtp5g_newlink` function to align with the latest changes in `net/rtnetlink.h` which moved parameters into a struct. This change was made so it only changes the function for kernel `6.15` onward and will leave the original function intact for older kernels.

Also don't be confused by the branch name.
In the beginning I thought compilation only fails because of the `CLEAN` entry, but later it surfaced that there are were more roadblocks.

If you have any questions or problems just ask me.

Cheers,
Julian