### PR TITLE
fix(gtp): initialize endmarker header length to 0 to avoid uninitialized value

### DIFF
--- a/src/gtpu/pktinfo.c
+++ b/src/gtpu/pktinfo.c
@@ -212,6 +212,8 @@ void gtp5g_fwd_emark_skb_ipv4(struct sk_buff *skb,
     gtp1->flags = GTPV1; /* v1, GTP-non-prime. */
     gtp1->type = GTPV1_MSG_TYPE_EMARK;
     gtp1->tid = epkt_info->teid;
+    gtp1->length = 0;
+
 
     rt = ip4_find_route_simple(skb, epkt_info->sk, dev, 
         epkt_info->role_addr /* Src Addr */ ,


### PR DESCRIPTION
Title:
Initialize end marker GTP header length to avoid uninitialized value

Description:
To prevent potential issues caused by the compiler not initializing the length field in the GTP header of the end marker, this PR explicitly sets it to 0 during initialization. This ensures consistency and avoids undefined behavior due to uninitialized memory.

