### PR TITLE
  Fix: GTP packet forwarding logic to use PDR direction for policer selection

### DIFF
--- a/src/gtpu/encap.c
+++ b/src/gtpu/encap.c
@@ -1049,8 +1049,13 @@ static int gtp5g_fwd_skb_ipv4(struct sk_buff *skb,
     volume_mbqe = ip4_rm_header(skb, 0);
 
     qer_with_rate = rcu_dereference(pdr->qer_with_rate);
-    if (qer_with_rate != NULL)
-        tp = qer_with_rate->dl_policer;
+    if (qer_with_rate != NULL){
+        if (is_uplink(pdr)) {
+            tp = qer_with_rate->ul_policer;
+        } else if (is_downlink(pdr)) {
+            tp = qer_with_rate->dl_policer;
+        }
+    }
     if (get_qos_enable() && tp != NULL) {
         color = policePacket(tp, volume_mbqe);
     }


### PR DESCRIPTION
# Fix: Update GTP packet forwarding logic to use PDR direction for policer selection

## Summary
Updated the packet forwarding logic in `gtp5g_fwd_skb_ipv4` to properly select the appropriate policer (uplink or downlink) based on the PDR direction instead of assuming downlink traffic.

## Background
Previously, the code always used the downlink policer (`dl_policer`) when QoS enforcement was enabled. This worked correctly when gtp5g operates in the 5GC role, where the function is only called on the N6 interface for downlink traffic. However, when gtp5g is used by RAN components, the traffic direction is reversed, requiring uplink policer selection instead.

## Changes
- Modified the policer selection logic to check PDR direction using `is_uplink()` and `is_downlink()` functions
- Uplink traffic now correctly uses `ul_policer`
- Downlink traffic continues to use `dl_policer`
- Maintains backward compatibility for existing 5GC deployments

## Impact
This change provides a unified approach that supports both 5GC and RAN deployment scenarios, ensuring correct QoS policer application regardless of the gtp5g usage context.