### PR TITLE
Kvmalloc and state sync

### DIFF
--- a/include/urr.h
+++ b/include/urr.h
@@ -4,6 +4,7 @@
 #include <linux/kernel.h>
 #include <linux/rculist.h>
 #include <linux/net.h>
+#include <linux/u64_stats_sync.h>
 
 #include "dev.h"
 #include "report.h"
@@ -80,7 +81,7 @@ struct urr {
 
     // For usage report volume measurement
     // TRIGGER_PERIO
-    spinlock_t period_vol_counter_lock;
+    struct u64_stats_sync period_vol_counter_sync;
     bool use_vol2;
     struct VolumeMeasurement vol1;
     struct VolumeMeasurement vol2;

--- a/src/genl/genl_urr.c
+++ b/src/genl/genl_urr.c
@@ -93,7 +93,7 @@ int gtp5g_genl_add_urr(struct sk_buff *skb, struct genl_info *info)
         goto end;
     }
 
-    spin_lock_init(&urr->period_vol_counter_lock);
+    u64_stats_init(&urr->period_vol_counter_sync);
     urr->dev = gtp->dev;
     urr->start_time = ktime_get_real();
 

--- a/src/gtpu/dev.c
+++ b/src/gtpu/dev.c
@@ -154,57 +154,57 @@ int dev_hashtable_new(struct gtp5g_dev *gtp, int hsize)
 {
     int i;
 
-    gtp->addr_hash = kmalloc_array(hsize, sizeof(struct hlist_head),
+    gtp->addr_hash = kvmalloc_array(hsize, sizeof(struct hlist_head),
         GFP_KERNEL);
     if (gtp->addr_hash == NULL)
         return -ENOMEM;
 
-    gtp->i_teid_hash = kmalloc_array(hsize, sizeof(struct hlist_head),
+    gtp->i_teid_hash = kvmalloc_array(hsize, sizeof(struct hlist_head),
         GFP_KERNEL);
     if (gtp->i_teid_hash == NULL)
         goto err1;
 
-    gtp->pdr_id_hash = kmalloc_array(hsize, sizeof(struct hlist_head),
+    gtp->pdr_id_hash = kvmalloc_array(hsize, sizeof(struct hlist_head),
         GFP_KERNEL);
     if (gtp->pdr_id_hash == NULL)
         goto err2;
 
-    gtp->far_id_hash = kmalloc_array(hsize, sizeof(struct hlist_head),
+    gtp->far_id_hash = kvmalloc_array(hsize, sizeof(struct hlist_head),
         GFP_KERNEL);
     if (gtp->far_id_hash == NULL)
         goto err3;
 
-    gtp->qer_id_hash = kmalloc_array(hsize, sizeof(struct hlist_head),
+    gtp->qer_id_hash = kvmalloc_array(hsize, sizeof(struct hlist_head),
         GFP_KERNEL);
     if (gtp->qer_id_hash == NULL)
         goto err4;
 
-    gtp->bar_id_hash = kmalloc_array(hsize, sizeof(struct hlist_head),
+    gtp->bar_id_hash = kvmalloc_array(hsize, sizeof(struct hlist_head),
             GFP_KERNEL);
     if (!gtp->bar_id_hash)
         goto err5;
 
-    gtp->urr_id_hash = kmalloc_array(hsize, sizeof(struct hlist_head),
+    gtp->urr_id_hash = kvmalloc_array(hsize, sizeof(struct hlist_head),
             GFP_KERNEL);
     if (!gtp->urr_id_hash)
         goto err6;
 
-    gtp->related_far_hash = kmalloc_array(hsize, sizeof(struct hlist_head),
+    gtp->related_far_hash = kvmalloc_array(hsize, sizeof(struct hlist_head),
         GFP_KERNEL);
     if (gtp->related_far_hash == NULL)
         goto err7;
 
-    gtp->related_qer_hash = kmalloc_array(hsize, sizeof(struct hlist_head),
+    gtp->related_qer_hash = kvmalloc_array(hsize, sizeof(struct hlist_head),
         GFP_KERNEL);
     if (gtp->related_qer_hash == NULL)
         goto err8;
 
-    gtp->related_bar_hash = kmalloc_array(hsize, sizeof(struct hlist_head),
+    gtp->related_bar_hash = kvmalloc_array(hsize, sizeof(struct hlist_head),
             GFP_KERNEL);
     if (!gtp->related_bar_hash)
         goto err9;
 
-    gtp->related_urr_hash = kmalloc_array(hsize, sizeof(struct hlist_head),
+    gtp->related_urr_hash = kvmalloc_array(hsize, sizeof(struct hlist_head),
             GFP_KERNEL);
     if (!gtp->related_urr_hash)
         goto err10;
@@ -227,25 +227,25 @@ int dev_hashtable_new(struct gtp5g_dev *gtp, int hsize)
 
     return 0;
 err10:
-    kfree(gtp->related_bar_hash);
+    kvfree(gtp->related_bar_hash);
 err9:
-    kfree(gtp->related_qer_hash);
+    kvfree(gtp->related_qer_hash);
 err8:
-    kfree(gtp->related_far_hash);
+    kvfree(gtp->related_far_hash);
 err7:
-    kfree(gtp->urr_id_hash);
+    kvfree(gtp->urr_id_hash);
 err6:
-    kfree(gtp->bar_id_hash);
+    kvfree(gtp->bar_id_hash);
 err5:
-    kfree(gtp->qer_id_hash);
+    kvfree(gtp->qer_id_hash);
 err4:
-    kfree(gtp->far_id_hash);
+    kvfree(gtp->far_id_hash);
 err3:
-    kfree(gtp->pdr_id_hash);
+    kvfree(gtp->pdr_id_hash);
 err2:
-    kfree(gtp->i_teid_hash);
+    kvfree(gtp->i_teid_hash);
 err1:
-    kfree(gtp->addr_hash);
+    kvfree(gtp->addr_hash);
     return -ENOMEM;
 }
 
@@ -272,15 +272,15 @@ void gtp5g_hashtable_free(struct gtp5g_dev *gtp)
     }
 
     synchronize_rcu();
-    kfree(gtp->addr_hash);
-    kfree(gtp->i_teid_hash);
-    kfree(gtp->pdr_id_hash);
-    kfree(gtp->far_id_hash);
-    kfree(gtp->qer_id_hash);
-    kfree(gtp->bar_id_hash);
-    kfree(gtp->urr_id_hash);
-    kfree(gtp->related_far_hash);
-    kfree(gtp->related_qer_hash);
-    kfree(gtp->related_bar_hash);
-    kfree(gtp->related_urr_hash);
+    kvfree(gtp->addr_hash);
+    kvfree(gtp->i_teid_hash);
+    kvfree(gtp->pdr_id_hash);
+    kvfree(gtp->far_id_hash);
+    kvfree(gtp->qer_id_hash);
+    kvfree(gtp->bar_id_hash);
+    kvfree(gtp->urr_id_hash);
+    kvfree(gtp->related_far_hash);
+    kvfree(gtp->related_qer_hash);
+    kvfree(gtp->related_bar_hash);
+    kvfree(gtp->related_urr_hash);
 }

--- a/src/gtpu/encap.c
+++ b/src/gtpu/encap.c
@@ -622,10 +622,11 @@ static struct VolumeMeasurement *get_urr_counter_by_trigger(struct urr *urr, u32
 
 static inline void update_period_vol_counter(struct urr *urr, u64 vol, bool uplink, bool mnop) {
     struct VolumeMeasurement *urr_counter = NULL;
-    spin_lock(&urr->period_vol_counter_lock);
+    
+    u64_stats_update_begin(&urr->period_vol_counter_sync);
     urr_counter = get_period_vol_counter(urr, urr->use_vol2);
     update_counter(urr_counter, vol, uplink, mnop);
-    spin_unlock(&urr->period_vol_counter_lock);
+    u64_stats_update_end(&urr->period_vol_counter_sync);
 }
 
 int update_urr_counter_and_send_report(struct pdr *pdr, struct far *far, u64 vol, u64 vol_mbqe) {


### PR DESCRIPTION
This PR includes the following fixes:

- Memory allocation:
   Replaced kmalloc_array with kvmalloc_array to handle large allocations and avoid memory allocation failures.

- Usage report synchronization
   Refined the sync mechanism to prevent potential soft lockups.