### PR TITLE
Fix/abnormal packet stats

### DIFF
--- a/src/gtpu/dev.c
+++ b/src/gtpu/dev.c
@@ -43,6 +43,7 @@ struct gtp5g_dev *gtp5g_find_dev(struct net *src_net, int ifindex, int netnsfd)
 }
 
 static inline bool is_pkt_action_valid(int pkt_action) {
+    /* Only count tx stats when packet was actually forwarded; drop/error paths must be excluded */
     return pkt_action == PKT_FORWARDED;
 }
 

--- a/src/gtpu/dev.c
+++ b/src/gtpu/dev.c
@@ -43,7 +43,7 @@ struct gtp5g_dev *gtp5g_find_dev(struct net *src_net, int ifindex, int netnsfd)
 }
 
 static inline bool is_pkt_action_valid(int pkt_action) {
-    return pkt_action != PKT_DROPPED && pkt_action != PKT_DROPPED_AND_FREED;
+    return pkt_action == PKT_FORWARDED;
 }
 
 void update_usage_statistic(struct gtp5g_dev *gtp, u64 rxVol, u64 txVol,


### PR DESCRIPTION
Ensure usage accounting only treats packets with pkt_action == PKT_FORWARDED as transmitted so that downlink tx counters reflect real egress traffic instead of counting failed lookups or buffered packets.