### PR TITLE
feat: urr to far management

### DIFF
--- a/include/urr.h
+++ b/include/urr.h
@@ -97,6 +97,7 @@ struct urr {
     // for quota exhausted
     bool quota_exhausted;
     u16 *pdrids;
+    u32 *farids;
     u16 *actions;
     u32 pdr_num;
 

--- a/src/pfcp/urr.c
+++ b/src/pfcp/urr.c
@@ -32,6 +32,13 @@ void urr_context_delete(struct urr *urr)
     if (!urr)
         return;
 
+    // If URR is being deleted while quota is still exhausted,
+    // restore FAR actions to prevent permanent DROP state
+    if (urr->quota_exhausted) {
+        GTP5G_ERR(NULL, "URR (%u) deleted while quota exhausted, force restoring FAR actions", urr->id);
+        urr_reverse_quota_exhaust_action(urr, gtp);
+    }
+
     if (!hlist_unhashed(&urr->hlist_id))
         hlist_del_rcu(&urr->hlist_id);
 
@@ -43,6 +50,14 @@ void urr_context_delete(struct urr *urr)
             unix_sock_client_delete(pdr_node->pdr);
         }
     }
+
+    // Free allocated memory for quota exhausted state
+    if (urr->pdrids)
+        kfree(urr->pdrids);
+    if (urr->farids)
+        kfree(urr->farids);
+    if (urr->actions)
+        kfree(urr->actions);
 
     call_rcu(&urr->rcu_head, urr_context_free);
 }
@@ -86,6 +101,7 @@ void urr_quota_exhaust_action(struct urr *urr, struct gtp5g_dev *gtp)
     struct pdr_node *pdr_node;
     char seid_urr_id_hexstr[SEID_U32ID_HEX_STR_LEN] = {0};
     u16 *actions = NULL, *pdrids = NULL;
+    u32 *farids = NULL;
     struct far *far;
 
     if (urr->quota_exhausted) {
@@ -97,30 +113,59 @@ void urr_quota_exhaust_action(struct urr *urr, struct gtp5g_dev *gtp)
     urr->pdr_num = 0;
 
     pdrids = kzalloc(MAX_PDR_PER_SESSION * sizeof(u16), GFP_KERNEL);
+    farids = kzalloc(MAX_PDR_PER_SESSION * sizeof(u32), GFP_KERNEL);
     actions = kzalloc(MAX_PDR_PER_SESSION * sizeof(u16), GFP_KERNEL);
-    if (!pdrids || !actions)
+    if (!pdrids || !farids || !actions)
         goto fail;
 
     seid_urr_id_to_hex_str(urr->seid, urr->id, seid_urr_id_hexstr);
     head = &gtp->related_urr_hash[str_hashfn(seid_urr_id_hexstr) % gtp->hash_size];
+    
+    rcu_read_lock();
     //each pdr that associate with the urr drop pkt
     hlist_for_each_entry_rcu(pdr_node, head, hlist) {
         if (find_urr_id_in_pdr(pdr_node->pdr, urr->id)) {
+            if (urr->pdr_num >= MAX_PDR_PER_SESSION) {
+                GTP5G_ERR(NULL, "URR (%u) exceeds MAX_PDR_PER_SESSION\n", urr->id);
+                break;
+            }
+            
             pdrids[urr->pdr_num] = pdr_node->pdr->id;
             far = rcu_dereference(pdr_node->pdr->far);
             if (far != NULL) {
-                actions[urr->pdr_num++] = far->action;
-
+                farids[urr->pdr_num] = far->id;     // Save FAR ID
+                actions[urr->pdr_num] = far->action; // Save original action
+                urr->pdr_num++;
+                
                 far->action = FAR_ACTION_DROP;
+                GTP5G_ERR(NULL, "URR (%u) quota exhausted, set FAR (%u) action to drop\n", urr->id, far->id);
             }
         }
     }
+    rcu_read_unlock();
 
     if (urr->pdr_num > 0) {
         urr->pdrids = kzalloc(urr->pdr_num * sizeof(u16), GFP_KERNEL);
+        urr->farids = kzalloc(urr->pdr_num * sizeof(u32), GFP_KERNEL);
         urr->actions = kzalloc(urr->pdr_num * sizeof(u16), GFP_KERNEL);
+        
+        if (!urr->pdrids || !urr->farids || !urr->actions) {
+            GTP5G_ERR(NULL, "URR (%u) failed to allocate memory for saving FAR states\n", urr->id);
+            if (urr->pdrids)
+                kfree(urr->pdrids);
+            if (urr->farids)
+                kfree(urr->farids);
+            if (urr->actions)
+                kfree(urr->actions);
+            urr->pdrids = NULL;
+            urr->farids = NULL;
+            urr->actions = NULL;
+            urr->pdr_num = 0;
+            goto fail;
+        }
 
         memcpy(urr->pdrids, pdrids, urr->pdr_num * sizeof(u16));
+        memcpy(urr->farids, farids, urr->pdr_num * sizeof(u32));
         memcpy(urr->actions, actions, urr->pdr_num * sizeof(u16));
     }
 
@@ -130,15 +175,14 @@ void urr_quota_exhaust_action(struct urr *urr, struct gtp5g_dev *gtp)
 fail:
     if (pdrids)
         kfree(pdrids);
+    if (farids)
+        kfree(farids);
     if (actions)
         kfree(actions);
 }
 
 void urr_reverse_quota_exhaust_action(struct urr *urr, struct gtp5g_dev *gtp)
 {
-    struct hlist_head *head;
-    struct pdr_node *pdr_node;
-    char seid_urr_id_hexstr[SEID_U32ID_HEX_STR_LEN] = {0};
     int i;
     struct far *far;
 
@@ -147,29 +191,34 @@ void urr_reverse_quota_exhaust_action(struct urr *urr, struct gtp5g_dev *gtp)
         return;
     }
 
-    seid_urr_id_to_hex_str(urr->seid, urr->id, seid_urr_id_hexstr);
-    head = &gtp->related_urr_hash[str_hashfn(seid_urr_id_hexstr) % gtp->hash_size];
-
-    //each pdr that associate with the urr resume it's normal action
-    hlist_for_each_entry_rcu(pdr_node, head, hlist) {
-        if (find_urr_id_in_pdr(pdr_node->pdr, urr->id)) {
-            for (i = 0; i < urr->pdr_num; i++) {
-                if (urr->pdrids[i] == pdr_node->pdr->id) {
-                    far = rcu_dereference(pdr_node->pdr->far);
-                    if (far != NULL) {
-                        far->action = urr->actions[i];
-                    }
-                }
-            }
+    rcu_read_lock();
+    // Restore each FAR action by FAR ID directly, not through PDR
+    for (i = 0; i < urr->pdr_num; i++) {
+        far = find_far_by_id(gtp, urr->seid, urr->farids[i]);
+        if (far != NULL) {
+            far->action = urr->actions[i];
+            GTP5G_INF(NULL, "URR (%u) restore FAR (%u) action to %u\n", urr->id, far->id, far->action);
+        } else {
+            GTP5G_WAR(NULL, "URR (%u) cannot find FAR (%u) to restore action\n", urr->id, urr->farids[i]);
         }
     }
+    rcu_read_unlock();
 
     urr->quota_exhausted = false;
+    urr->info &= ~URR_INFO_INAM;
 
-    if (urr->pdrids)
+    if (urr->pdrids) {
         kfree(urr->pdrids);
-    if (urr->actions)
+        urr->pdrids = NULL;
+    }
+    if (urr->farids) {
+        kfree(urr->farids);
+        urr->farids = NULL;
+    }
+    if (urr->actions) {
         kfree(urr->actions);
+        urr->actions = NULL;
+    }
 }
 
 void urr_append(u64 seid, u32 urr_id, struct urr *urr, struct gtp5g_dev *gtp)


### PR DESCRIPTION
At before, URR will only depend on PDRs and there was a #TODO comment said:

```go
// TODO: FAR ID for Quota Action IE for indicating the action while no quota is granted
```

What I do in this PR:
Change 1: Track FAR by ID instead of through PDR
Change 2: Automatic cleanup on URR deletion
Change 3: Added RCU lock protection for safe traversal
Change 4: Added INFO_INAM flag reverse(in `urr_reverse_quota_exhaust_action`)
Change 5: Some URR releated logs.