### PR TITLE
Fix IFLA_GTP5G_PDR_HASHSIZE divide error

### DIFF
--- a/src/gtpu/link.c
+++ b/src/gtpu/link.c
@@ -105,8 +105,14 @@ static int gtp5g_newlink(struct net *src_net, struct net_device *dev,
     
     if (!data[IFLA_GTP5G_PDR_HASHSIZE])
         hashsize = 1024;
-    else
+    else {
         hashsize = nla_get_u32(data[IFLA_GTP5G_PDR_HASHSIZE]);
+        if (!hashsize) {
+            if (sk)
+                gtp5g_encap_disable(sk);
+            return -EINVAL;
+        }
+    }
 
     err = dev_hashtable_new(gtp, hashsize);
     if (err < 0) {


### PR DESCRIPTION
The gtp5g_newlink function fails to validate the IFLA_GTP5G_PDR_HASHSIZE attribute, allowing a user to set the hash table size to zero. Subsequently, accessing this hash table (e.g., via find_urr_by_id) triggers a modulo operation with this zero value, resulting in a "divide error" and an immediate kernel panic.