### PR TITLE
fix: release locks in QER UPDATE path to prevent deadlock

### DIFF
--- a/src/genl/genl_qer.c
+++ b/src/genl/genl_qer.c
@@ -73,9 +73,13 @@ int gtp5g_genl_add_qer(struct sk_buff *skb, struct genl_info *info)
         }
         err = qer_fill(qer, gtp, info);
         if (err) {
+            rcu_read_unlock();
+            rtnl_unlock();
             qer_context_delete(qer);
             return err;
         }
+        rcu_read_unlock();
+        rtnl_unlock();
         return 0;
     }
 


### PR DESCRIPTION
## Problem

In `gtp5g_genl_add_qer()`, the UPDATE path acquires `rcu_read_lock()` and
`rtnl_lock()` at the start of the function, but never releases them before
returning. On the **second** `UpdateQER` call, `rtnl_lock()` deadlocks
since it was never released from the first call.

**Symptom**: After the first QER update succeeds, any subsequent QER update
causes the entire UPF to hang indefinitely. All PFCP sessions time out,
SMF releases the UPF association, and active PDU sessions collapse.

## Root Cause

```c
// UPDATE path — locks acquired at function entry, but missing on return:
err = qer_fill(qer, gtp, info);
if (err) {
    qer_context_delete(qer);
    return err;   // BUG: rcu_read_unlock() / rtnl_unlock() never called
}
return 0;         // BUG: rcu_read_unlock() / rtnl_unlock() never called
```

Note: the CREATE path and other early-return paths in the same function
correctly call both unlock functions before returning.

## Fix
Add the missing rcu_read_unlock() and rtnl_unlock() to both return
paths in the UPDATE block.

## Testing
Tested with free5gc v4.2.0 + UERANSIM + vendor PCF:

PCF notifies session-AMBR 4Mbps → 2Mbps → 4Mbps
All three QER updates succeed without deadlock
UPF remains responsive throughout
Note: gtp5g rate limiting is disabled by default. To enable:


echo 1 > /proc/gtp5g/qos
Without this, QER policers are created but policePacket() is never
called, so rate limiting has no effect even with valid MBR values.
Verify current state with: cat /proc/gtp5g/qos

## Related
This fix is part of an end-to-end 5G QoS enforcement feature for
PCF-triggered AMBR updates:

free5gc/smf — [feat: update QER when PCF notifies AMBR change](https://github.com/free5gc/smf/pull/191): SMF now propagates PCF SmPolicyUpdateNotification AMBR changes to UPF via PFCP SessionModificationRequest. Without this gtp5g fix, the second AMBR update would deadlock UPF and bring down all active sessions.
