### PR TITLE
fix(trTCM): fix EBS integer division and stale token bucket comparison

### DIFF
--- a/src/gtpu/trTCM.c
+++ b/src/gtpu/trTCM.c
@@ -29,7 +29,7 @@ TrafficPolicer* newTrafficPolicer(u64 kbitRate) {
     }
 
     // EBS size = CIR * BURST_DURATION
-    p->ebs = p->byteRate * (BURST_DURATION / MILLISECONDS_PER_SECOND); // bytes
+    p->ebs = p->byteRate * BURST_DURATION / MILLISECONDS_PER_SECOND; // bytes
 
     // fill buckets at the begining
     p->tc = p->cbs; 
@@ -75,17 +75,17 @@ Color policePacket(TrafficPolicer* p, int pktLen) {
         tc = p->cbs; 
     }
    
-    if (p->tc >= pktLen) {
+    if (tc >= pktLen) {
         p->tc = tc - pktLen;
         p->te = te;
-        spin_unlock(&p->lock); 
+        spin_unlock(&p->lock);
         return Green;
     }
 
-    if (p->te >= pktLen) {
+    if (te >= pktLen) {
         p->tc = tc;
         p->te = te - pktLen;
-        spin_unlock(&p->lock); 
+        spin_unlock(&p->lock);
         return Yellow;
     }
 


### PR DESCRIPTION
## Problem

Two bugs in `src/gtpu/trTCM.c`:

### 1. EBS always zero (integer division)

```c
// BURST_DURATION=200, MILLISECONDS_PER_SECOND=1000
// 200 / 1000 = 0 in integer arithmetic
p->ebs = p->byteRate * (BURST_DURATION / MILLISECONDS_PER_SECOND);
```

`p->ebs` is always 0, so the Yellow bucket has zero capacity and is
never used. Any packet that overflows the Green bucket goes directly
to Red instead of Yellow.

` I think this does not prevent rate limiting from working, but eliminates the
Yellow state entirely — packets either pass (Green) or are dropped (Red),
with no excess burst tolerance as originally intended.`

### 2. Stale bucket values used for classification

`policePacket()` computes the refilled token counts into local variables
`tc` and `te`, but then uses the pre-refill `p->tc` / `p->te` for the
Green/Yellow classification:

```c
tc = p->tc + refillTokens;  // refilled value in local var
...
if (p->tc >= pktLen) {      // bug: uses pre-refill value
if (p->te >= pktLen) {      // bug: uses pre-refill value
```

A packet that fits in the refilled bucket but not the stale one is
incorrectly classified as Yellow or Red.

`This causes occasional misclassification at token refill boundaries,
resulting in marginally more drops than necessary, but does not
significantly affect average throughput in steady-state traffic.`

## Fix

1. Reorder EBS calculation: `p->byteRate * BURST_DURATION / MILLISECONDS_PER_SECOND`
2. Use local `tc` / `te` instead of `p->tc` / `p->te` for classification

## Test Environment

- free5gc v4.2.0
- Vendor PCF (N7 policy control)
- UERANSIM (gNB Session-AMBR rate limiter disabled, as it does not distinguish GBR/Non-GBR flows)
- Kernel 5.4, gtp5g v0.9.14

## Impact

These bugs do not completely disable QoS rate limiting — the Green bucket
(CBS) still enforces the CIR correctly. However, the Yellow bucket is
rendered non-functional and color classification is occasionally incorrect.
The fixes restore the intended trTCM behavior as specified in RFC 2698.

## Test Results

Two iperf3 downlink sessions against separate servers:
- **GBR flow** (SDF filter, MFBR = 10 Mbps): stabilizes at ~9–11 Mbps ✓
- **Non-GBR flow** (Session-AMBR = 4 Mbps): stabilizes at ~3.5–4.5 Mbps ✓

```
# GBR flow (7.153.214.207, MFBR=10Mbps)
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec  2.56 MBytes  21.5 Mbits/sec   <- initial CBS burst
[  5]   1.00-2.00   sec  1.08 MBytes  9.08 Mbits/sec
[  5]   2.00-3.00   sec  1.33 MBytes  11.2 Mbits/sec
[  5]   3.00-4.00   sec  1.09 MBytes  9.13 Mbits/sec

# Non-GBR flow (7.153.214.208, Session-AMBR=4Mbps)
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec  1.01 MBytes  8.46 Mbits/sec   <- initial CBS burst
[  5]   1.00-2.00   sec   434 KBytes  3.56 Mbits/sec
[  5]   2.00-3.00   sec   548 KBytes  4.49 Mbits/sec
[  5]   3.00-4.00   sec   437 KBytes  3.58 Mbits/sec
```

The first-second burst is expected: the CBS bucket (CIR × 1 s) is full
at session start and consumed by TCP slow start before steady state.
