### PR TITLE
fix: Missing rtnl_unlock when pdr_fill fails

### DIFF
--- a/src/genl/genl_far.c
+++ b/src/genl/genl_far.c
@@ -34,7 +34,7 @@ int gtp5g_genl_add_far(struct sk_buff *skb, struct genl_info *info)
     int netnsfd;
     u64 seid;
     u32 far_id;
-    int err;
+    int err = 0;
     u8 flag;
     struct gtp5g_emark_pktinfo epkt_info;
 
@@ -52,9 +52,8 @@ int gtp5g_genl_add_far(struct sk_buff *skb, struct genl_info *info)
 
     gtp = gtp5g_find_dev(sock_net(skb->sk), ifindex, netnsfd);
     if (!gtp) {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -ENODEV;
+        err = -ENODEV;
+        goto out;
     }
 
     if (info->attrs[GTP5G_FAR_SEID]) {
@@ -66,31 +65,26 @@ int gtp5g_genl_add_far(struct sk_buff *skb, struct genl_info *info)
     if (info->attrs[GTP5G_FAR_ID]) {
         far_id = nla_get_u32(info->attrs[GTP5G_FAR_ID]);
     } else {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -ENODEV;
+        err = -ENODEV;
+        goto out;
     }
 
     far = find_far_by_id(gtp, seid, far_id);
     if (far) {
         if (info->nlhdr->nlmsg_flags & NLM_F_EXCL) {
-            rcu_read_unlock();
-            rtnl_unlock();
-            return -EEXIST;
+            err = -EEXIST;
+            goto out;
         }
         if (!(info->nlhdr->nlmsg_flags & NLM_F_REPLACE)) {
-            rcu_read_unlock();
-            rtnl_unlock();
-            return -EOPNOTSUPP;
+            err = -EOPNOTSUPP;
+            goto out;
         }
 
         flag = 0;
         err = far_fill(far, gtp, info, &flag, &epkt_info);
         if (err) {
             far_context_delete(far);
-            rcu_read_unlock();
-            rtnl_unlock();
-            return err;
+            goto out;
         }
 
         // Send GTP-U End marker to gNB
@@ -100,59 +94,50 @@ int gtp5g_genl_add_far(struct sk_buff *skb, struct genl_info *info)
              * */
             struct sk_buff *skb = __netdev_alloc_skb(gtp->dev, 52, GFP_KERNEL);
             if (!skb) {
-                rcu_read_unlock();
-                rtnl_unlock();
-                return 0;
+                goto out;
             }
             skb_reserve(skb, 2);
             skb->protocol = eth_type_trans(skb, gtp->dev);
             gtp5g_fwd_emark_skb_ipv4(skb, gtp->dev, &epkt_info);
         }
-        rcu_read_unlock();
-        rtnl_unlock();
-        return 0;
+        goto out;
     }
 
     if (info->nlhdr->nlmsg_flags & NLM_F_REPLACE) {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -ENOENT;
+        err = -ENOENT;
+        goto out;
     }
 
     if (info->nlhdr->nlmsg_flags & NLM_F_APPEND) {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -EOPNOTSUPP;
+        err = -EOPNOTSUPP;
+        goto out;
     }
 
     // Check only at the creation part
     if (!info->attrs[GTP5G_FAR_APPLY_ACTION]) {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -EINVAL;
+        err = -EINVAL;
+        goto out;
     }
 
     far = kzalloc(sizeof(*far), GFP_ATOMIC);
     if (!far) {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -ENOMEM;
+        err = -ENOMEM;
+        goto out;
     }
     far->dev = gtp->dev;
 
     err = far_fill(far, gtp, info, NULL, NULL);
     if (err) {
         far_context_delete(far);
-        rcu_read_unlock();
-        rtnl_unlock();
-        return err;
+        goto out;
     }
 
     far_append(seid, far_id, far, gtp);
  
+out:
     rcu_read_unlock();
     rtnl_unlock();
-    return 0;
+    return err;
 }  
 
 int gtp5g_genl_del_far(struct sk_buff *skb, struct genl_info *info)

--- a/src/genl/genl_pdr.c
+++ b/src/genl/genl_pdr.c
@@ -40,7 +40,7 @@ int gtp5g_genl_add_pdr(struct sk_buff *skb, struct genl_info *info)
     int netnsfd;
     u64 seid = 0;
     u16 pdr_id;
-    int err;
+    int err = 0;
 
     if (info->attrs[GTP5G_LINK]) {
         ifindex = nla_get_u32(info->attrs[GTP5G_LINK]);
@@ -59,9 +59,8 @@ int gtp5g_genl_add_pdr(struct sk_buff *skb, struct genl_info *info)
 
     gtp = gtp5g_find_dev(sock_net(skb->sk), ifindex, netnsfd);
     if (!gtp) {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -ENODEV;
+        err = -ENODEV;
+        goto out;
     }
 
     if (info->attrs[GTP5G_PDR_SEID]) {
@@ -71,59 +70,50 @@ int gtp5g_genl_add_pdr(struct sk_buff *skb, struct genl_info *info)
     if (info->attrs[GTP5G_PDR_ID]) {
         pdr_id = nla_get_u32(info->attrs[GTP5G_PDR_ID]);
     } else {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -ENODEV;
+        err = -ENODEV;
+        goto out;
     }
 
     pdr = find_pdr_by_id(gtp, seid, pdr_id);
     if (pdr) {
         if (info->nlhdr->nlmsg_flags & NLM_F_EXCL) {
-            rcu_read_unlock();
-            rtnl_unlock();
-            return -EEXIST;
+            err = -EEXIST;
+            goto out;
         }
         if (!(info->nlhdr->nlmsg_flags & NLM_F_REPLACE)) {
-            rcu_read_unlock();
-            rtnl_unlock();
-            return -EOPNOTSUPP;
+            err = -EOPNOTSUPP;
+            goto out;
         }
 
         err = pdr_fill(pdr, gtp, info);
         if (err) {
             pdr_context_delete(pdr);
-            return err;
+            goto out;
         }
 
-        rcu_read_unlock();
-        rtnl_unlock();
-        return 0;
+        goto out;
     }
 
     if (info->nlhdr->nlmsg_flags & NLM_F_REPLACE) {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -ENOENT;
+        err = -ENOENT;
+        goto out;
     }
 
     if (info->nlhdr->nlmsg_flags & NLM_F_APPEND) {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -EOPNOTSUPP;
+        err = -EOPNOTSUPP;
+        goto out;
     }
 
     // Check only at the creation part
     if (!info->attrs[GTP5G_PDR_PRECEDENCE]) {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -EINVAL;
+        err = -EINVAL;
+        goto out;
     }
 
     pdr = kzalloc(sizeof(*pdr), GFP_ATOMIC);
     if (!pdr) {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -ENOMEM;
+        err = -ENOMEM;
+        goto out;
     }
 
     sock_hold(gtp->sk1u);
@@ -133,17 +123,16 @@ int gtp5g_genl_add_pdr(struct sk_buff *skb, struct genl_info *info)
     err = pdr_fill(pdr, gtp, info);
     if (err) {
         pdr_context_delete(pdr);
-        rcu_read_unlock();
-        rtnl_unlock();
-        return err;
+        goto out;
     }
 
     pdr_append(seid, pdr_id, pdr, gtp);
 
+out:
     rcu_read_unlock();
     rtnl_unlock();
 
-    return 0;
+    return err;
 }
 
 int gtp5g_genl_del_pdr(struct sk_buff *skb, struct genl_info *info)

--- a/src/genl/genl_qer.c
+++ b/src/genl/genl_qer.c
@@ -24,7 +24,7 @@ int gtp5g_genl_add_qer(struct sk_buff *skb, struct genl_info *info)
     int netnsfd;
     u64 seid;
     u32 qer_id;
-    int err;
+    int err = 0;
 
     if (!info->attrs[GTP5G_LINK])
         return -EINVAL;
@@ -40,9 +40,8 @@ int gtp5g_genl_add_qer(struct sk_buff *skb, struct genl_info *info)
 
     gtp = gtp5g_find_dev(sock_net(skb->sk), ifindex, netnsfd);
     if (!gtp) {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -ENODEV;
+        err = -ENODEV;
+        goto out;
     }
 
     if (info->attrs[GTP5G_QER_SEID]) {
@@ -54,52 +53,42 @@ int gtp5g_genl_add_qer(struct sk_buff *skb, struct genl_info *info)
     if (info->attrs[GTP5G_QER_ID]) {
         qer_id = nla_get_u32(info->attrs[GTP5G_QER_ID]);
     } else {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -ENODEV;
+        err = -ENODEV;
+        goto out;
     }
 
     qer = find_qer_by_id(gtp, seid, qer_id);
     if (qer) {
         if (info->nlhdr->nlmsg_flags & NLM_F_EXCL) {
-            rcu_read_unlock();
-            rtnl_unlock();
-            return -EEXIST;
+            err = -EEXIST;
+            goto out;
         }
         if (!(info->nlhdr->nlmsg_flags & NLM_F_REPLACE)) {
-            rcu_read_unlock();
-            rtnl_unlock();
-            return -EOPNOTSUPP;
+            err = -EOPNOTSUPP;
+            goto out;
         }
         err = qer_fill(qer, gtp, info);
         if (err) {
-            rcu_read_unlock();
-            rtnl_unlock();
             qer_context_delete(qer);
-            return err;
+            goto out;
         }
-        rcu_read_unlock();
-        rtnl_unlock();
-        return 0;
+        goto out;
     }
 
     if (info->nlhdr->nlmsg_flags & NLM_F_REPLACE) {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -ENOENT;
+        err = -ENOENT;
+        goto out;
     }
 
     if (info->nlhdr->nlmsg_flags & NLM_F_APPEND) {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -EOPNOTSUPP;
+        err = -EOPNOTSUPP;
+        goto out;
     }
 
     qer = kzalloc(sizeof(*qer), GFP_ATOMIC);
     if (!qer) {
-        rcu_read_unlock();
-        rtnl_unlock();
-        return -ENOMEM;
+        err = -ENOMEM;
+        goto out;
     }
 
     qer->dev = gtp->dev;
@@ -107,16 +96,15 @@ int gtp5g_genl_add_qer(struct sk_buff *skb, struct genl_info *info)
     err = qer_fill(qer, gtp, info);
     if (err) {
         qer_context_delete(qer);
-        rcu_read_unlock();
-        rtnl_unlock();
-        return err;
+        goto out;
     }
 
     qer_append(seid, qer_id, qer, gtp);
 
+out:
     rcu_read_unlock();
     rtnl_unlock();
-    return 0;
+    return err;
 }
 
 int gtp5g_genl_del_qer(struct sk_buff *skb, struct genl_info *info)


### PR DESCRIPTION
Fixes a lock leak bug in the PDR update error path where pdr_fill() failure returned without releasing locks.

Also refactored duplicated rcu_read_unlock()/rtnl_unlock() sequences with a goto-out pattern in `gtp5g_genl_add_{far,pdr,qer}`