### PR TITLE
fix: validate far_id in pdr_fill to prevent invalid access

### DIFF
--- a/src/genl/genl_pdr.c
+++ b/src/genl/genl_pdr.c
@@ -463,6 +463,11 @@ static int pdr_fill(struct pdr *pdr, struct gtp5g_dev *gtp, struct genl_info *in
         return -EINVAL;
 
     pdr->af = AF_INET;
+
+    if (!pdr->far_id) {
+        return -EINVAL;
+    }
+
     far = find_far_by_id(gtp, pdr->seid, *pdr->far_id);
     if (!far) {
         return -EINVAL;


### PR DESCRIPTION
fixing [issue 173](https://github.com/free5gc/gtp5g/issues/173)

This pull request introduces an additional validation step in the `pdr_fill` function to improve input checking and error handling. The main change ensures that a `far_id` is present before attempting to use it, preventing potential null pointer dereferences and making the code more robust.

Input validation improvements:

* Added a check in `pdr_fill` (in `genl_pdr.c`) to return `-EINVAL` if `pdr->far_id` is not set, ensuring that the function does not proceed with a missing or invalid `far_id`.