### PR TITLE
fix: updating URR period volume counter

### DIFF
--- a/src/gtpu/encap.c
+++ b/src/gtpu/encap.c
@@ -712,10 +712,8 @@ int update_urr_counter_and_send_report(struct pdr *pdr, struct far *far, u64 vol
                         triggers[report_num] = USAR_TRIGGER_VOLTH;
                         urrs[report_num++] = urr;
                     }
-                } else {
-                    if (urr->period == 0) {
-                        continue;
-                    }
+                }
+                if (urr->period != 0) {
                     update_period_vol_counter(urr, volume, uplink, mnop);
                 }
                 if (urr->trigger & URR_RPT_TRIGGER_VOLQU) {


### PR DESCRIPTION
fix issue https://github.com/free5gc/smf/issues/223

Refactored logic to update the period volume counter only when `urr->period` is nonzero, removing an incorrect `continue` statement and associated `else` block.